### PR TITLE
配置 Cloud Agent 开发环境并修复无头截图跨平台问题

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,4 @@
+{
+  "name": "CA Prototype",
+  "install": "node --version && chrome --version"
+}

--- a/runtime/shoot.mjs
+++ b/runtime/shoot.mjs
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 /* 无头截图：按标注组分别截图；URL 带 state=<组>&collapsed=1。
    Viewer 在 collapsed=1 时进入纯页面态，自动隐藏 Mark、右下角折叠钮与交互闪电。 */
-import { existsSync, mkdirSync, readFileSync, statSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync } from 'node:fs';
 import { spawn, spawnSync } from 'node:child_process';
 import { dirname, join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
 import { pathToFileURL } from 'node:url';
 
 const args = process.argv.slice(2);
@@ -61,6 +62,8 @@ function shoot(group, exe) {
   return new Promise((resolveShot) => {
     const url = pathToFileURL(htmlPath).href + '?state=' + encodeURIComponent(group) + '&collapsed=1';
     const outFile = join(outDir, group + '.png');
+    /* 独立临时 profile：避免与已打开的浏览器争用默认用户目录导致 SingletonLock 启动失败。 */
+    const profileDir = mkdtempSync(join(tmpdir(), 'ca-shoot-'));
     /* --no-sandbox / --disable-dev-shm-usage：Linux 容器与 CI 无头环境下必需，Windows/Mac 上无副作用。 */
     const child = spawn(exe, [
       '--headless=new',
@@ -69,6 +72,7 @@ function shoot(group, exe) {
       '--disable-gpu',
       '--hide-scrollbars',
       '--force-device-scale-factor=1',
+      '--user-data-dir=' + profileDir,
       '--window-size=' + width + ',' + height,
       '--virtual-time-budget=2000',
       '--screenshot=' + outFile,
@@ -80,6 +84,7 @@ function shoot(group, exe) {
       if (settled) return;
       settled = true;
       try { child.kill('SIGKILL'); } catch (_) { /* 进程可能已退出 */ }
+      try { rmSync(profileDir, { recursive: true, force: true }); } catch (_) { /* 临时目录清理失败可忽略 */ }
       if (ok) {
         console.log(`✓ [${group}] ${outFile}`);
       } else {

--- a/runtime/shoot.mjs
+++ b/runtime/shoot.mjs
@@ -61,8 +61,11 @@ function shoot(group, exe) {
   return new Promise((resolveShot) => {
     const url = pathToFileURL(htmlPath).href + '?state=' + encodeURIComponent(group) + '&collapsed=1';
     const outFile = join(outDir, group + '.png');
+    /* --no-sandbox / --disable-dev-shm-usage：Linux 容器与 CI 无头环境下必需，Windows/Mac 上无副作用。 */
     const child = spawn(exe, [
       '--headless=new',
+      '--no-sandbox',
+      '--disable-dev-shm-usage',
       '--disable-gpu',
       '--hide-scrollbars',
       '--force-device-scale-factor=1',
@@ -71,37 +74,41 @@ function shoot(group, exe) {
       '--screenshot=' + outFile,
       url
     ], { stdio: 'ignore' });
+    let settled = false;
+    /* 统一收尾：主动结束浏览器并按产物是否落盘判定成败，兼容截图后不自动退出的无头 Chrome。 */
+    const finish = (ok, code) => {
+      if (settled) return;
+      settled = true;
+      try { child.kill('SIGKILL'); } catch (_) { /* 进程可能已退出 */ }
+      if (ok) {
+        console.log(`✓ [${group}] ${outFile}`);
+      } else {
+        console.error(`✗ [${group}] 截图失败（${code}）：${url}`);
+        process.exitCode = 1;
+      }
+      resolveShot(ok);
+    };
     child.on('error', () => {
       console.error(`✗ 启动浏览器失败：${exe}`);
-      process.exitCode = 1;
-      resolveShot(false);
+      finish(false, 'spawn');
     });
-    /* 用 close（stdio 完全关闭）而非 exit：Edge 截图文件可能在进程退出后仍有落盘延迟。 */
-    child.on('close', (code) => {
-      if (code === 0) waitForFile(outFile, 4000).then((exists) => {
-        if (exists) {
-          console.log(`✓ [${group}] ${outFile}`);
-          resolveShot(true);
-        } else {
-          console.error(`✗ [${group}] 截图文件未生成（exit ${code}）：${url}`);
-          resolveShot(false);
-        }
-      });
-      else {
-        console.error(`✗ [${group}] 截图失败（exit ${code}）：${url}`);
-        resolveShot(false);
-      }
-    });
+    /* 部分无头 Chrome 截图后不自动退出：轮询产物落盘（大小稳定）后主动收尾，不再依赖 close 事件。 */
+    waitForFile(outFile, 20000).then((exists) => finish(exists, 'timeout'));
   });
 }
 
-/* 轮询等待截图文件落盘，最多等待 timeout 毫秒。 */
+/* 轮询等待截图文件落盘，最多等待 timeout 毫秒。要求大小非零且连续两次相等，避免读到写入中途的半截文件。 */
 function waitForFile(path, timeout) {
   return new Promise((resolveWait) => {
     const start = Date.now();
+    let lastSize = -1;
     (function check() {
-      if (existsSync(path)) return resolveWait(true);
-      if (Date.now() - start >= timeout) return resolveWait(false);
+      if (existsSync(path)) {
+        const size = statSync(path).size;
+        if (size > 0 && size === lastSize) return resolveWait(true);
+        lastSize = size;
+      }
+      if (Date.now() - start >= timeout) return resolveWait(existsSync(path) && statSync(path).size > 0);
       setTimeout(check, 150);
     })();
   });
@@ -114,6 +121,10 @@ function resolveBrowser() {
   const candidates = [
     'msedge',
     'chrome',
+    'google-chrome',
+    'google-chrome-stable',
+    'chromium',
+    'chromium-browser',
     'C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe',
     'C:\\Program Files\\Microsoft\\Edge\\Application\\msedge.exe',
     'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景

为本仓库（CA Prototype，纯 Node.js 原生 HTML 原型生成/评审工具集）配置可复现的 Cloud Agent 开发环境，并验证运行时工具端到端可用。

## 环境结论

- 运行时仅依赖 **Node.js 内建模块**（无 `package.json`、无第三方依赖），截图功能依赖本机 **Chrome/Edge**。
- 默认镜像已内置 Node.js（`v22`）与 Chrome（`148`），因此无需自定义 Dockerfile 或依赖安装步骤。

## 改动

- 新增 `.cursor/environment.json`：以仓库内配置固定环境（最高优先级，合并后对后续 Agent 自动生效），`install` 阶段仅校验 Node.js 与 Chrome 两项前置条件（幂等、可终止）。
- 修复 `runtime/shoot.mjs` 在 Linux 容器/CI 无头环境下无法出图的根因：
  - 补充 `--no-sandbox` / `--disable-dev-shm-usage` 启动参数（容器必需，Windows/Mac 无副作用）。
  - 截图后不再依赖 Chrome 自动退出：改为轮询产物落盘（大小稳定）后主动结束进程；`waitForFile` 增加大小稳定校验，避免读到写入中途的半截文件。
  - 每次截图使用 `mkdtemp` 创建的独立 `--user-data-dir`，收尾时清理，修复本机已打开 Chrome 时因 `SingletonLock` 导致的启动失败。
  - `resolveBrowser` 增补 `google-chrome` / `google-chrome-stable` / `chromium` 等 Linux 浏览器名，提升可移植性。

## 验证

- **install 幂等**：`node --version && chrome --version` 连续两次退出码 0。
- **草稿构建（全新 default 镜像 Pod）**：`install` 通过，输出 `v22.22.2` 与 `Google Chrome 148.0.7778.96`，`chrome` 在 PATH 上，退出码 0。
- **`runtime/shoot.mjs`**：对样例原型 4 个标注分组（base/create/edit/strategy）全部出图，耗时约 2s，退出码 0（修复前会挂起）；在已有 20 个 Chrome 进程运行时仍成功（验证 profile 隔离）。
- **`runtime/serve.mjs`**：本地作者服务在 `127.0.0.1:4178` 正常提供注入后的原型 HTML、作者资源（author-loader / editor / html-mark / inspector）与快照文件；Inspector 端点可将元素 token 解析到源码行号；编辑器写回快照（PUT）经浏览器实测生效。
- **`runtime/prepare-mark.mjs`**：inline 注入评审层并生成备份，`--remove` 幂等清理。

## 交付说明

环境为仓库内 `.cursor/environment.json` 管理，合并本 PR 到默认分支后即对后续 Cloud Agent 生效，无需在面板中额外保存。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3d9cbee3-d037-4347-aa0f-af2c000c209f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3d9cbee3-d037-4347-aa0f-af2c000c209f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

