### PR TITLE
fix: align manifest and docs with runtime restructure

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -4,7 +4,7 @@
 
 ## html-mark
 
-本项目评审层 `skills/html-prototype-build/runtime/html-mark.js` 基于
+本项目 Mark 评审工具 `skills/html-prototype-build/runtime/author/tools/mark/` 基于
 [xuxinmaxen/html-mark](https://github.com/xuxinmaxen/html-mark)
 （MIT No Attribution / MIT-0，Copyright 2026 Maxen Xu / @xuxinmaxen），并做了本地集成改动
 （主题色、与作者工具互斥、`Ctrl+Click` 打点等）。MIT-0 不强制署名；此处为溯源与致谢。

--- a/examples/minimal-notes/prototype/viewer.js
+++ b/examples/minimal-notes/prototype/viewer.js
@@ -36,7 +36,7 @@
     document.head.appendChild(style);
   }
 
-  /* 读取 ?product-only=1，供 shoot.mjs 截图时隐藏全部作者 overlay。 */
+  /* 读取 ?product-only=1，供 runtime/cli/screenshot.mjs 截图时隐藏全部作者 overlay。 */
   function readFromUrl() {
     try {
       return new URLSearchParams(window.location.search).get('product-only') === '1';

--- a/skills/html-prototype-build/addons/annotations/ui-annotations.html
+++ b/skills/html-prototype-build/addons/annotations/ui-annotations.html
@@ -1,9 +1,9 @@
 <!--
   UI 正式标注包：所有原型均加载，作为 Viewer 与统一状态协调器的运行时入口。
-  右栏 DOM、样式和连线逻辑由本 Skill 的 runtime/viewer.js 运行时创建，
+  右栏 DOM、样式和连线逻辑由本 Skill 的 runtime/client/notes/viewer.js 运行时创建，
   原型 HTML 不得硬编码右栏结构、卡片正文或连线逻辑。
   卡片只展示标题与正文；target.label 保留为结构化数据，不在卡片内重复显示。
-  作者态操作由 html-prototype-build 本地服务（serve.mjs）注入到卡片右上角和面板底部。
+  作者态操作由 html-prototype-build 本地服务（runtime/server/index.mjs）注入到卡片右上角和面板底部。
 -->
 
 <!-- 原型优先复用语义 id 作为稳定锚点；状态不存入 DOM 属性。 -->

--- a/skills/html-prototype-build/runtime/client/core/display-mode.js
+++ b/skills/html-prototype-build/runtime/client/core/display-mode.js
@@ -36,7 +36,7 @@
     document.head.appendChild(style);
   }
 
-  /* 读取 ?product-only=1，供 shoot.mjs 截图时隐藏全部作者 overlay。 */
+  /* 读取 ?product-only=1，供 runtime/cli/screenshot.mjs 截图时隐藏全部作者 overlay。 */
   function readFromUrl() {
     try {
       return new URLSearchParams(window.location.search).get('product-only') === '1';

--- a/skills/html-prototype-build/runtime/client/notes/viewer.js
+++ b/skills/html-prototype-build/runtime/client/notes/viewer.js
@@ -36,7 +36,7 @@
     document.head.appendChild(style);
   }
 
-  /* 读取 ?product-only=1，供 shoot.mjs 截图时隐藏全部作者 overlay。 */
+  /* 读取 ?product-only=1，供 runtime/cli/screenshot.mjs 截图时隐藏全部作者 overlay。 */
   function readFromUrl() {
     try {
       return new URLSearchParams(window.location.search).get('product-only') === '1';

--- a/skills/html-prototype-build/ui/packs/admin-desktop/components/data/_echarts-core/COMPONENT.md
+++ b/skills/html-prototype-build/ui/packs/admin-desktop/components/data/_echarts-core/COMPONENT.md
@@ -17,7 +17,7 @@ states:
 生成原型时需 copy：
 
 - `assets/echarts.min.js`（来自 skill vendor）
-- `prototype/chart-bridge.js`、`prototype/chart-presets.js`（来自 skill runtime）
+- `prototype/bridge.js`、`prototype/presets.js`（来自 `runtime/client/charts/`）
 
 ## 状态 Adapter
 

--- a/skills/html-prototype-build/ui/packs/admin-desktop/manifest.json
+++ b/skills/html-prototype-build/ui/packs/admin-desktop/manifest.json
@@ -498,8 +498,8 @@
         "vendor/echarts/echarts.min.js"
       ],
       "runtime": [
-        "runtime/chart-bridge.js",
-        "runtime/chart-presets.js"
+        "runtime/client/charts/bridge.js",
+        "runtime/client/charts/presets.js"
       ]
     },
     "data.chart-line": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

After the runtime directory restructure (`d495c2e`), `npm test` failed because the UI pack manifest still referenced old chart runtime paths. This PR fixes that and aligns a few remaining doc/code references.

## Changes

- **manifest.json**: `runtime/chart-bridge.js` / `chart-presets.js` → `runtime/client/charts/bridge.js` / `presets.js`
- **COMPONENT.md**: chart copy targets updated to `prototype/bridge.js` and `prototype/presets.js`
- **NOTICE**: html-mark attribution path updated to `runtime/author/tools/mark/`
- **ui-annotations.html**: comments updated to `runtime/client/notes/viewer.js` and `runtime/server/index.mjs`
- **viewer.js / display-mode.js**: comment references `shoot.mjs` → `runtime/cli/screenshot.mjs`

## Verification

- `npm test`: **60/60 passed**
- `runtime/server/index.mjs`: prototype, bootstrap, display-mode routes return 200
- `runtime/cli/screenshot.mjs`: 4/4 scenario screenshots generated
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-127548a7-9a4a-4ca7-8946-dd9a822fe188?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-127548a7-9a4a-4ca7-8946-dd9a822fe188&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

