### PR TITLE
fix: align manifest and docs after client/server split

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -4,7 +4,7 @@
 
 ## html-mark
 
-本项目评审层 `skills/html-prototype-build/runtime/html-mark.js` 基于
+本项目 Mark 评审工具 `skills/html-prototype-build/runtime/author/tools/mark/` 基于
 [xuxinmaxen/html-mark](https://github.com/xuxinmaxen/html-mark)
 （MIT No Attribution / MIT-0，Copyright 2026 Maxen Xu / @xuxinmaxen），并做了本地集成改动
 （主题色、与作者工具互斥、`Ctrl+Click` 打点等）。MIT-0 不强制署名；此处为溯源与致谢。

--- a/examples/minimal-notes/prototype/display-mode.js
+++ b/examples/minimal-notes/prototype/display-mode.js
@@ -36,7 +36,7 @@
     document.head.appendChild(style);
   }
 
-  /* 读取 ?product-only=1，供 shoot.mjs 截图时隐藏全部作者 overlay。 */
+  /* 读取 ?product-only=1，供 runtime/cli/screenshot.mjs 截图时隐藏全部作者 overlay。 */
   function readFromUrl() {
     try {
       return new URLSearchParams(window.location.search).get('product-only') === '1';

--- a/skills/html-prototype-build/runtime/client/core/display-mode.js
+++ b/skills/html-prototype-build/runtime/client/core/display-mode.js
@@ -36,7 +36,7 @@
     document.head.appendChild(style);
   }
 
-  /* 读取 ?product-only=1，供 shoot.mjs 截图时隐藏全部作者 overlay。 */
+  /* 读取 ?product-only=1，供 runtime/cli/screenshot.mjs 截图时隐藏全部作者 overlay。 */
   function readFromUrl() {
     try {
       return new URLSearchParams(window.location.search).get('product-only') === '1';

--- a/skills/html-prototype-build/ui/packs/admin-desktop/components/data/_echarts-core/COMPONENT.md
+++ b/skills/html-prototype-build/ui/packs/admin-desktop/components/data/_echarts-core/COMPONENT.md
@@ -17,7 +17,7 @@ states:
 生成原型时需 copy：
 
 - `assets/echarts.min.js`（来自 skill vendor）
-- `prototype/chart-bridge.js`、`prototype/chart-presets.js`（来自 skill runtime）
+- `prototype/bridge.js`、`prototype/presets.js`（来自 `runtime/client/charts/`）
 
 ## 状态 Adapter
 

--- a/skills/html-prototype-build/ui/packs/admin-desktop/manifest.json
+++ b/skills/html-prototype-build/ui/packs/admin-desktop/manifest.json
@@ -498,8 +498,8 @@
         "vendor/echarts/echarts.min.js"
       ],
       "runtime": [
-        "runtime/chart-bridge.js",
-        "runtime/chart-presets.js"
+        "runtime/client/charts/bridge.js",
+        "runtime/client/charts/presets.js"
       ]
     },
     "data.chart-line": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up alignment after the latest runtime refactor commits (`ef6c065`, `5e8ff60`, `f918fd2`). `npm test` was failing because `manifest.json` still referenced pre-restructure chart runtime paths.

## Changes

- **manifest.json**: chart runtime → `runtime/client/charts/bridge.js` / `presets.js`
- **_echarts-core/COMPONENT.md**: copy targets → `prototype/bridge.js` / `presets.js`
- **NOTICE**: html-mark attribution → `runtime/author/tools/mark/`
- **display-mode.js** (runtime + example): comment `shoot.mjs` → `runtime/cli/screenshot.mjs`

## Verification

- `npm test`: **69/69 passed**
- `runtime/server/index.mjs`: prototype / bootstrap / modes / state / static display-mode → 200
- `runtime/cli/screenshot.mjs`: 4/4 scenario screenshots
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-127548a7-9a4a-4ca7-8946-dd9a822fe188?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-127548a7-9a4a-4ca7-8946-dd9a822fe188&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

