### PR TITLE
release: v0.2.1 macOS shortcut compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to AI HTML Annotation will be documented in this file.
 
+## v0.2.1 — 2026-09-08
+
+### Fixed
+
+- macOS shortcut compatibility across Author Tools: shared `author/core/platform.js` for `⌘` vs `Ctrl` labels and modifier detection.
+- Notes Editor multiline save now accepts `⌘ + Enter` (and `Control + Enter`) on macOS, not only `Ctrl + Enter`.
+
+### Changed
+
+- Direct Edit and Mark empty-state hints show `⌘` on macOS instead of always `Ctrl`.
+- Root README and Skill references document macOS shortcuts for Edit, Mark, and Notes Editor.
+
+### Install / update
+
+```bash
+npx skills add https://github.com/Lisuiwen/ai-html-annotation --skill html-prototype-build
+```
+
 ## v0.2.0 — 2026-09-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Viewer keeps formal notes in a right-hand panel. You can add, edit, delete, and 
 
 ### 2. Author tools: edit the page or pin feedback for AI
 
-Author Tools bundles Direct Edit and Mark in one panel. Hold `Ctrl` and click an element to tweak styles or copy and save changes back to source HTML, or switch to Mark to drop removable review pins. Collect notes, then use `Copy all → For AI` to export selectors plus element HTML snapshots as editable context for an agent.
+Author Tools bundles Direct Edit and Mark in one panel. Hold `Ctrl` (macOS: `⌘`) and click an element to tweak styles or copy and save changes back to source HTML, or switch to Mark to drop removable review pins. Collect notes, then use `Copy all → For AI` to export selectors plus element HTML snapshots as editable context for an agent.
 
 ![Author Tools: Direct Edit and Mark for on-page edits and review pins](media/mark.gif)
 
@@ -73,7 +73,7 @@ Compose pages from a local UI pack with shared tokens, components, and patterns.
 
 ### Direct edits on the real DOM
 
-Direct Edit loads only in the localhost authoring session. Hold `Ctrl` and select an element to preview style or copy changes in the browser, then save them back to `prototype.html` through the authoring server—without hand-editing selectors or hunting through the file tree for every tweak.
+Direct Edit loads only in the localhost authoring session. Hold `Ctrl` (macOS: `⌘`) and select an element to preview style or copy changes in the browser, then save them back to `prototype.html` through the authoring server—without hand-editing selectors or hunting through the file tree for every tweak.
 
 ### Executable review context
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -49,7 +49,7 @@ Viewer 把正式说明组织在页面右侧。你可以新增、编辑、删除�
 
 ### 2. 作者工具：直接改页面或打点交给 AI
 
-Author Tools 在同一面板中提供 Direct Edit 与 Mark。按住 `Ctrl` 点击元素即可调整样式或文案并写回源 HTML；切换到 Mark 可在真实元素上添加可移除的评审标记，集中查看意见后使用 `Copy all → For AI`，复制包含 selector 与元素 HTML 快照的修改上下文，直接交给 AI。
+Author Tools 在同一面板中提供 Direct Edit 与 Mark。按住 `Ctrl`（macOS：`⌘`）点击元素即可调整样式或文案并写回源 HTML；切换到 Mark 可在真实元素上添加可移除的评审标记，集中查看意见后使用 `Copy all → For AI`，复制包含 selector 与元素 HTML 快照的修改上下文，直接交给 AI。
 
 ![Author Tools：Direct Edit 与 Mark 的页面修改与评审打点](media/mark.gif)
 

--- a/skills/html-prototype-build/references/local-authoring.md
+++ b/skills/html-prototype-build/references/local-authoring.md
@@ -24,10 +24,22 @@ Author Tools 浮层中，`Edit` 与 `Mark` 为同一面板的两个 Tab；右侧
 |---|---|
 | Direct Edit | 打开 Author Tools → `Edit`，按住 `Ctrl`（macOS 为 `⌘`）点击页面元素；修改后保存写回源 HTML。 |
 | Mark 评审 | 打开 Author Tools → `Mark`，或按 `M`；按住 `Ctrl`（macOS 为 `⌘`）点击元素添加 pin。 |
-| 编辑正式说明 | 双击说明标题、正文或页头文案；标题/页头 `Enter` 保存，正文 `Ctrl + Enter` 保存，`Esc` 取消。 |
+| 编辑正式说明 | 双击说明标题、正文或页头文案；标题/页头 `Enter` 保存，正文 `Ctrl + Enter`（macOS：`⌘ + Enter`）保存，`Esc` 取消。 |
 | 管理正式说明 | 使用 `+`、编辑、目标绑定、删除和拖拽排序。 |
 | Inspector | 按住 `Alt + Shift` 悬停并点击目标，跳转 IDE 源码位置。 |
 | 切换页面场景 | 使用右侧场景按钮，或 `?scene=<场景-id>`。 |
+
+## 平台差异
+
+Direct Edit 与 Mark 共用 `author/core/picker.js` 的元素选择逻辑：
+
+- **Windows / Linux**：按住 `Ctrl` + 左键点击选中元素；普通点击不拦截页面。
+- **macOS**：优先 `⌘` + 左键；`Control` + 左键触发 contextmenu 时也会选中（Edit 与 Mark 均适用）。
+
+正式说明正文保存快捷键：
+
+- **Windows / Linux**：`Ctrl + Enter`
+- **macOS**：`⌘ + Enter` 或 `Control + Enter`
 
 ## Agent 边界
 

--- a/skills/html-prototype-build/references/review-mark.md
+++ b/skills/html-prototype-build/references/review-mark.md
@@ -24,8 +24,10 @@ Mark 数据只保存在当前页面 pathname 对应的浏览器 localStorage；�
 
 ## 平台差异
 
-- **Windows / Linux**：按住 `Ctrl` + 左键点击打点；普通点击不拦截页面。
-- **macOS**：优先 `⌘` + 左键；`Control`+左键触发 contextmenu 时 Mark 也会处理该手势。
+Direct Edit 与 Mark 共用 `author/core/picker.js` 的元素选择逻辑：
+
+- **Windows / Linux**：按住 `Ctrl` + 左键点击打点或选中；普通点击不拦截页面。
+- **macOS**：优先 `⌘` + 左键；`Control`+左键触发 contextmenu 时也会处理该手势。
 
 ## 与其他工具的边界
 

--- a/skills/html-prototype-build/runtime/author/bootstrap.js
+++ b/skills/html-prototype-build/runtime/author/bootstrap.js
@@ -28,6 +28,7 @@
 
   async function init() {
     try {
+      if (!window.AuthorToolsPlatform) await load('/__prototype-author/author/core/platform.js');
       if (!window.PrototypeAuthor) await load('/__prototype-author/author/core/modes.js');
       if (!window.PrototypeAuthorChrome) await load('/__prototype-author/client/core/display-mode.js');
       if (!window.AuthorToolsSelector) await load('/__prototype-author/author/core/selector.js');

--- a/skills/html-prototype-build/runtime/author/core/picker.js
+++ b/skills/html-prototype-build/runtime/author/core/picker.js
@@ -4,18 +4,21 @@
 
   if (window.AuthorToolsPicker) return;
 
-  var IS_MAC = /Mac|iPhone|iPad|iPod/.test(navigator.platform || '') ||
-    (navigator.userAgentData && navigator.userAgentData.platform === 'macOS');
+  function isMac() {
+    return window.AuthorToolsPlatform ? window.AuthorToolsPlatform.isMac() :
+      /Mac|iPhone|iPad|iPod/.test(navigator.platform || '') ||
+      (navigator.userAgentData && navigator.userAgentData.platform === 'macOS');
+  }
 
   function pickerModifierActive(event) {
+    if (window.AuthorToolsPlatform) return window.AuthorToolsPlatform.pickerModifierActive(event);
     if (!event) return false;
-    if (IS_MAC) return !!(event.metaKey || event.ctrlKey);
     return !!event.ctrlKey;
   }
 
   function pickerClickModifier(event) {
+    if (window.AuthorToolsPlatform) return window.AuthorToolsPlatform.pickerClickModifier(event);
     if (!event) return false;
-    if (IS_MAC) return !!event.metaKey;
     return !!event.ctrlKey;
   }
 
@@ -175,7 +178,7 @@
 
   /* macOS：Control+左键触发 contextmenu 而非 click。 */
   function handleContextMenu(event) {
-    if (!state.owner || !IS_MAC || !event.ctrlKey) return;
+    if (!state.owner || !isMac() || !event.ctrlKey) return;
     selectFromEvent(event);
   }
 

--- a/skills/html-prototype-build/runtime/author/core/platform.js
+++ b/skills/html-prototype-build/runtime/author/core/platform.js
@@ -1,0 +1,31 @@
+/* 作者工具平台检测：macOS 修饰键文案与 picker/save 手势判定。 */
+(function () {
+  'use strict';
+
+  if (window.AuthorToolsPlatform) return;
+
+  var IS_MAC = /Mac|iPhone|iPad|iPod/.test(navigator.platform || '') ||
+    (navigator.userAgentData && navigator.userAgentData.platform === 'macOS');
+
+  function modifierActive(event, macAcceptsCtrl) {
+    if (!event) return false;
+    if (IS_MAC) return !!(event.metaKey || (macAcceptsCtrl && event.ctrlKey));
+    return !!event.ctrlKey;
+  }
+
+  window.AuthorToolsPlatform = {
+    isMac: function () { return IS_MAC; },
+    clickModifierLabel: function () { return IS_MAC ? '⌘' : 'Ctrl'; },
+    pickerModifierActive: function (event) {
+      return modifierActive(event, true);
+    },
+    pickerClickModifier: function (event) {
+      if (!event) return false;
+      if (IS_MAC) return !!event.metaKey;
+      return !!event.ctrlKey;
+    },
+    saveModifierActive: function (event) {
+      return modifierActive(event, true);
+    }
+  };
+})();

--- a/skills/html-prototype-build/runtime/author/tools/direct-edit/panel.js
+++ b/skills/html-prototype-build/runtime/author/tools/direct-edit/panel.js
@@ -102,11 +102,15 @@
       '</div>';
   }
 
+  function clickModifierLabel() {
+    return window.AuthorToolsPlatform ? window.AuthorToolsPlatform.clickModifierLabel() : 'Ctrl';
+  }
+
   function render(container, session, meta) {
     if (!session) {
       container.innerHTML =
         '<div class="at-edit-body">' +
-        '  <div class="at-edit-empty">按住 <kbd>Ctrl</kbd> 点击页面元素以选中。<br>普通点击保持页面交互。</div>' +
+        '  <div class="at-edit-empty">按住 <kbd>' + esc(clickModifierLabel()) + '</kbd> 点击页面元素以选中。<br>普通点击保持页面交互。</div>' +
         '</div>' +
         '<div class="at-edit-foot">' +
         '  <button type="button" class="at-btn" data-act="cancel" disabled>取消</button>' +

--- a/skills/html-prototype-build/runtime/author/tools/mark/index.js
+++ b/skills/html-prototype-build/runtime/author/tools/mark/index.js
@@ -22,6 +22,10 @@
     });
   }
 
+  function clickModifierLabel() {
+    return window.AuthorToolsPlatform ? window.AuthorToolsPlatform.clickModifierLabel() : 'Ctrl';
+  }
+
   function textOf(el) {
     return (el.textContent || '').replace(/\s+/g, ' ').trim().slice(0, 80);
   }
@@ -217,7 +221,7 @@
     var list = container.querySelector('#mm-list');
     if (!list) return;
     if (!annotations.length) {
-      list.innerHTML = '<div class="mm-empty">按住 <kbd>Ctrl</kbd> 点击页面元素即可落下 pin。<br><kbd>M</kbd> 打开本 Tab · <kbd>⌫</kbd> 删除上一条</div>';
+      list.innerHTML = '<div class="mm-empty">按住 <kbd>' + esc(clickModifierLabel()) + '</kbd> 点击页面元素即可落下 pin。<br><kbd>M</kbd> 打开本 Tab · <kbd>⌫</kbd> 删除上一条</div>';
       return;
     }
     list.innerHTML = annotations.map(function (ann, index) {
@@ -265,7 +269,7 @@
 
   function copyAll() {
     if (!annotations.length) {
-      toast('还没有标注 — 先按住 Ctrl 点击打一个 pin。');
+      toast('还没有标注 — 先按住 ' + clickModifierLabel() + ' 点击打一个 pin。');
       return;
     }
     var fmt = container.querySelector('#mm-fmt').value;

--- a/skills/html-prototype-build/runtime/author/tools/notes-editor/index.js
+++ b/skills/html-prototype-build/runtime/author/tools/notes-editor/index.js
@@ -64,6 +64,11 @@
     }
   }
 
+  function saveModifierActive(event) {
+    if (window.AuthorToolsPlatform) return window.AuthorToolsPlatform.saveModifierActive(event);
+    return !!(event && event.ctrlKey);
+  }
+
   function startEdit(element, getter, setter, multiline) {
     if (element.querySelector('input,textarea')) return;
     var control = document.createElement(multiline ? 'textarea' : 'input');
@@ -88,7 +93,7 @@
         event.preventDefault();
         renderData();
         enhance();
-      } else if (event.key === 'Enter' && (!multiline || event.ctrlKey)) {
+      } else if (event.key === 'Enter' && (!multiline || saveModifierActive(event))) {
         event.preventDefault();
         control.blur();
       }

--- a/tests/runtime/author/bootstrap.test.mjs
+++ b/tests/runtime/author/bootstrap.test.mjs
@@ -22,6 +22,7 @@ test('bootstrap 在 DOM loading 时延迟初始化', async () => {
 test('bootstrap 只负责加载新 client/author 资源路径', async () => {
   const { source } = await boot();
   for (const path of [
+    '/__prototype-author/author/core/platform.js',
     '/__prototype-author/author/core/modes.js',
     '/__prototype-author/client/core/display-mode.js',
     '/__prototype-author/author/core/selector.js',
@@ -44,6 +45,7 @@ test('bootstrap 只负责加载新 client/author 资源路径', async () => {
 
 test('bootstrap 在工具脚本之前加载各自 CSS 依赖', async () => {
   const { source } = await boot();
+  const platform = source.indexOf('/__prototype-author/author/core/platform.js');
   const selector = source.indexOf('/__prototype-author/author/core/selector.js');
   const notesCss = source.indexOf('/__prototype-author/author/tools/notes-editor/index.css');
   const model = source.indexOf('/__prototype-author/author/tools/notes-editor/model.js');
@@ -51,6 +53,6 @@ test('bootstrap 在工具脚本之前加载各自 CSS 依赖', async () => {
   const picker = source.indexOf('/__prototype-author/author/core/picker.js');
   const markCss = source.indexOf('/__prototype-author/author/tools/mark/index.css');
   const markController = source.indexOf('/__prototype-author/author/tools/mark/index.js');
-  assert.ok(selector >= 0 && notesCss > selector && model > notesCss && notesController > model && picker > selector);
+  assert.ok(platform >= 0 && selector > platform && notesCss > selector && model > notesCss && notesController > model && picker > selector);
   assert.ok(markCss >= 0 && markController > markCss);
 });

--- a/tests/runtime/author/core/picker.test.mjs
+++ b/tests/runtime/author/core/picker.test.mjs
@@ -12,6 +12,7 @@ async function boot(platform = 'Win32') {
   const document = { body, documentElement: html, addEventListener: (name, fn) => listeners.set(name, fn), removeEventListener: (name) => listeners.delete(name) };
   const window = { CSS: { escape: (value) => String(value).replace(/:/g, '\\:') }, addEventListener: (name, fn) => windowListeners.set(name, fn), removeEventListener: (name) => windowListeners.delete(name) }; window.window = window;
   const context = { window, document, navigator: { platform }, requestAnimationFrame: (fn) => { fn(); return 1; }, CSS: window.CSS, console, String, Array, Object };
+  vm.runInNewContext(await readFile(new URL('../../../../skills/html-prototype-build/runtime/author/core/platform.js', import.meta.url), 'utf8'), context, { filename: 'platform.js' });
   vm.runInNewContext(selectorSource, context, { filename: 'selector.js' });
   vm.runInNewContext(source, context, { filename: 'picker.js' });
   return { window, listeners, body, source };
@@ -47,4 +48,28 @@ test('stableSelector 通过共享 selector 保持 id、note target、cssPath 行
 test('切换 owner 会释放旧 owner 的监听与高亮', async () => {
   const { window, listeners, body } = await boot(); const target = element('div', body); target.id = 'x'; window.AuthorToolsPicker.activate({ owner: 'edit' }); listeners.get('click')(clickEvent(target));
   assert.equal(target.classList.contains('at-hl'), true); window.AuthorToolsPicker.activate({ owner: 'mark', persistSelection: false }); assert.equal(target.classList.contains('at-hl'), false); window.AuthorToolsPicker.release('mark'); assert.equal(listeners.has('click'), false);
+});
+
+test('macOS 上 metaKey+Click 选择元素', async () => {
+  const { window, listeners, body } = await boot('MacIntel'); const target = element('button', body);
+  target.matches = (selector) => selector.includes('button'); let selected = null;
+  window.AuthorToolsPicker.activate({ owner: 'edit', onSelect: (el) => { selected = el; } });
+  listeners.get('click')({ ...clickEvent(target), ctrlKey: false, metaKey: false });
+  assert.equal(selected, null);
+  listeners.get('click')({ ...clickEvent(target), ctrlKey: false, metaKey: true });
+  assert.equal(selected, target);
+});
+
+test('macOS 上 Control+左键走 contextmenu 也能选择', async () => {
+  const { window, listeners, body } = await boot('MacIntel'); const target = element('div', body);
+  target.id = 'box'; let selected = null;
+  window.AuthorToolsPicker.activate({ owner: 'mark', onSelect: (el) => { selected = el; } });
+  listeners.get('contextmenu')({
+    target,
+    ctrlKey: true,
+    metaKey: false,
+    preventDefault() {},
+    stopPropagation() {}
+  });
+  assert.equal(selected, target);
 });

--- a/tests/runtime/author/core/platform.test.mjs
+++ b/tests/runtime/author/core/platform.test.mjs
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+import vm from 'node:vm';
+
+const sourceUrl = new URL('../../../../skills/html-prototype-build/runtime/author/core/platform.js', import.meta.url);
+
+async function boot(platform = 'Win32') {
+  const source = await readFile(sourceUrl, 'utf8');
+  const window = {};
+  window.window = window;
+  vm.runInNewContext(source, {
+    window,
+    navigator: { platform, userAgentData: platform === 'macOS' ? { platform: 'macOS' } : undefined }
+  }, { filename: 'platform.js' });
+  return window.AuthorToolsPlatform;
+}
+
+test('clickModifierLabel 在 macOS 返回 ⌘，其他平台返回 Ctrl', async () => {
+  assert.equal((await boot('MacIntel')).clickModifierLabel(), '⌘');
+  assert.equal((await boot('Win32')).clickModifierLabel(), 'Ctrl');
+});
+
+test('pickerClickModifier 在 macOS 只认 metaKey', async () => {
+  const api = await boot('MacIntel');
+  assert.equal(api.pickerClickModifier({ metaKey: true, ctrlKey: false }), true);
+  assert.equal(api.pickerClickModifier({ metaKey: false, ctrlKey: true }), false);
+});
+
+test('pickerModifierActive 在 macOS 接受 metaKey 或 ctrlKey', async () => {
+  const api = await boot('MacIntel');
+  assert.equal(api.pickerModifierActive({ metaKey: true, ctrlKey: false }), true);
+  assert.equal(api.pickerModifierActive({ metaKey: false, ctrlKey: true }), true);
+});
+
+test('saveModifierActive 在 macOS 接受 ⌘ 或 Control', async () => {
+  const api = await boot('MacIntel');
+  assert.equal(api.saveModifierActive({ metaKey: true, ctrlKey: false }), true);
+  assert.equal(api.saveModifierActive({ metaKey: false, ctrlKey: true }), true);
+  assert.equal(api.saveModifierActive({ metaKey: false, ctrlKey: false }), false);
+});
+
+test('saveModifierActive 在 Windows 只认 Ctrl', async () => {
+  const api = await boot('Win32');
+  assert.equal(api.saveModifierActive({ metaKey: true, ctrlKey: false }), false);
+  assert.equal(api.saveModifierActive({ metaKey: false, ctrlKey: true }), true);
+});

--- a/tests/runtime/author/tools/notes-editor/index.test.mjs
+++ b/tests/runtime/author/tools/notes-editor/index.test.mjs
@@ -50,7 +50,8 @@ test('NotesEditor 将数据与 selector 规则委托给共享模型，并保留�
   assert.doesNotMatch(source, /function selectorFor\(/);
   assert.match(source, /function startPick/);
   assert.match(source, /beforeunload/);
-  assert.match(source, /window\.PrototypeAuthor\.register\('notes-target'/);
+  assert.match(source, /saveModifierActive/);
+  assert.match(source, /AuthorToolsPlatform\.saveModifierActive/);
 });
 
 test('NotesEditor 作者样式独立于 controller JS', async () => {

--- a/tests/runtime/index.test.mjs
+++ b/tests/runtime/index.test.mjs
@@ -13,6 +13,7 @@ import './client/charts/presets.test.mjs';
 import './author/bootstrap.test.mjs';
 import './author/core/modes.test.mjs';
 import './author/core/selector.test.mjs';
+import './author/core/platform.test.mjs';
 import './author/core/picker.test.mjs';
 import './author/shell/index.test.mjs';
 import './author/tools/direct-edit/index.test.mjs';


### PR DESCRIPTION
## Summary
- Add shared `author/core/platform.js` for macOS `⌘` vs `Ctrl` modifier detection and UI labels
- Fix Notes Editor multiline save on macOS (`⌘ + Enter` / `Control + Enter`)
- Update Direct Edit / Mark empty-state hints and README / Skill docs

## Test plan
- [x] `npm test` (101 tests)
- [ ] Merge PR, then tag `v0.2.1` on master and push tag

## Changelog

See CHANGELOG.md v0.2.1 section.