### PR TITLE
feat: localize Viewer, Author Tools, and example UI to English

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to AI HTML Annotation will be documented in this file.
 
+## v0.3.1 — 2026-09-10
+
+### Changed
+
+- Localized Viewer, Author Tools, and the minimal example UI copy to English (`lang="en"`): scenario switching, note rails, Direct Edit, and Mark labels, hints, toasts, and error messages.
+- The minimal example annotations and scenario labels now use English copy, staying synchronized with the Skill template.
+
+### Fixed
+
+- Synced the Viewer contract test with the localized runtime error messages.
+
+### Install / update
+
+```bash
+npx skills add https://github.com/Lisuiwen/ai-html-annotation --skill html-prototype-build
+```
+
 ## v0.3.0 — 2026-09-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ This root README covers install and product overview only. Day-to-day usage live
 - Skill overview and collaboration model → [`skills/html-prototype-build/README.md`](skills/html-prototype-build/README.md)
 - Agent routing and hard constraints → [`skills/html-prototype-build/SKILL.md`](skills/html-prototype-build/SKILL.md)
 - Task guides with commands (authoring, review, screenshots) → [`skills/html-prototype-build/references/`](skills/html-prototype-build/references/)
-- Walkthrough sample → [`examples/minimal-notes`](examples/minimal-notes) (demo UI copy is Chinese)
+- Walkthrough sample → [`examples/minimal-notes`](examples/minimal-notes)
 
 Those Skill docs are currently Chinese—ask an agent that can read them, or follow the Skill README entry points.
 

--- a/examples/minimal-notes/prototype.html
+++ b/examples/minimal-notes/prototype.html
@@ -1,9 +1,9 @@
 <!doctype html>
-<html lang="zh-CN">
+<html lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>项目配置中心 - 配置项维护</title>
+  <title>Project Config Center - Configuration Items</title>
   <link rel="stylesheet" href="./prototype/prototype.css">
 
 </head>
@@ -12,36 +12,36 @@
     <!-- 项目配置中心列表页。 -->
     <div class="ui-shell">
       <header class="ui-header">
-        <div class="ui-brand"><span class="ui-brand-mark" aria-hidden="true">D</span><span>项目配置中心</span></div>
-        <div class="ui-breadcrumb">⌂　/　配置管理　/　配置项</div>
+        <div class="ui-brand"><span class="ui-brand-mark" aria-hidden="true">D</span><span>Project Config Center</span></div>
+        <div class="ui-breadcrumb">⌂　/　Configuration　/　Configuration Items</div>
         <div class="ui-header-actions">
           <span aria-hidden="true">文</span>
-          <select class="ui-tenant" aria-label="工作区"><option>示例工作区</option></select>
+          <select class="ui-tenant" aria-label="Workspace"><option>Demo workspace</option></select>
           <span aria-hidden="true">♙</span><span>demo-user</span>
         </div>
       </header>
 
       <div class="ui-shell-body">
         <aside class="ui-sider">
-          <nav class="ui-menu" aria-label="系统菜单">
-            <span class="ui-menu-item">欢迎</span>
-            <span class="ui-menu-group">项目管理 <span>⌄</span></span>
-            <span class="ui-menu-item">项目列表</span>
-            <span class="ui-menu-item">成员管理</span>
-            <span class="ui-menu-item">版本记录</span>
-            <span class="ui-menu-group">任务中心 <span>›</span></span>
-            <span class="ui-menu-group">资源管理 <span>›</span></span>
-            <span class="ui-menu-group">数据分析 <span>›</span></span>
-            <span class="ui-menu-group">通知中心 <span>›</span></span>
-            <span class="ui-menu-group">统计报表 <span>›</span></span>
-            <span class="ui-menu-group">系统设置 <span>⌄</span></span>
+          <nav class="ui-menu" aria-label="System menu">
+            <span class="ui-menu-item">Welcome</span>
+            <span class="ui-menu-group">Project Management <span>⌄</span></span>
+            <span class="ui-menu-item">Project List</span>
+            <span class="ui-menu-item">Member Management</span>
+            <span class="ui-menu-item">Version History</span>
+            <span class="ui-menu-group">Task Center <span>›</span></span>
+            <span class="ui-menu-group">Resource Management <span>›</span></span>
+            <span class="ui-menu-group">Data Analysis <span>›</span></span>
+            <span class="ui-menu-group">Notification Center <span>›</span></span>
+            <span class="ui-menu-group">Statistics & Reports <span>›</span></span>
+            <span class="ui-menu-group">System Settings <span>⌄</span></span>
             <div class="ui-menu-sub">
               <button
                 id="menuConfig"
                 class="ui-menu-item is-active"
                 type="button"
                 data-ui-interactive>
-                配置项
+                Configuration Items
               </button>
             </div>
           </nav>
@@ -51,12 +51,12 @@
           <article class="ui-content-card">
             <section class="ui-filter" id="filterArea">
               <div class="ui-filter-fields">
-                <input class="ui-input" id="filterName" aria-label="配置项名称" placeholder="配置项名称 请输入">
-                <input class="ui-input" id="filterCode" aria-label="配置项编码" placeholder="配置项编码 请输入">
+                <input class="ui-input" id="filterName" aria-label="Configuration item name" placeholder="Enter configuration item name">
+                <input class="ui-input" id="filterCode" aria-label="Configuration item code" placeholder="Enter configuration item code">
               </div>
               <div class="ui-actions">
-                <button class="ui-button" type="button" id="resetButton">重置</button>
-                <button class="ui-button ui-button--primary" type="button" id="queryButton">查询</button>
+                <button class="ui-button" type="button" id="resetButton">Reset</button>
+                <button class="ui-button ui-button--primary" type="button" id="queryButton">Search</button>
               </div>
             </section>
 
@@ -66,7 +66,7 @@
                 type="button"
                 id="createButton"
                 data-ui-interactive>
-                新建配置项
+                New Configuration Item
               </button>
             </div>
 
@@ -75,39 +75,39 @@
                 <table class="ui-table">
                   <thead>
                     <tr>
-                      <th>配置项名称</th>
-                      <th>配置项编码</th>
-                      <th>描述</th>
-                      <th>创建者</th>
-                      <th>创建时间</th>
-                      <th>操作</th>
+                      <th>Name</th>
+                      <th>Code</th>
+                      <th>Description</th>
+                      <th>Created By</th>
+                      <th>Created At</th>
+                      <th>Actions</th>
                     </tr>
                   </thead>
                   <tbody id="preconditionRows">
                     <tr>
-                      <td>通知开关</td>
+                      <td>Notification Switch</td>
                       <td>notification_enabled</td>
-                      <td>是否启用通知，0 表示关闭，1 表示开启</td>
+                      <td>Whether notifications are enabled; 0 means off, 1 means on</td>
                       <td>maintainer-a</td>
                       <td>2026-01-15 09:30:00</td>
                       <td>
                         <div class="ui-table-actions">
-                          <button class="ui-button ui-button--text" type="button" data-action="edit" data-ui-interactive>编辑</button>
-                          <button class="ui-button ui-button--text" type="button" data-action="delete">删除</button>
+                          <button class="ui-button ui-button--text" type="button" data-action="edit" data-ui-interactive>Edit</button>
+                          <button class="ui-button ui-button--text" type="button" data-action="delete">Delete</button>
                         </div>
                       </td>
                     </tr>
-                    <tr><td>默认超时时间</td><td>default_timeout</td><td>任务默认超时时间，单位为分钟</td><td>maintainer-b</td><td>2026-01-16 10:15:00</td><td><button class="ui-button ui-button--text" type="button" data-action="edit">编辑</button>　<button class="ui-button ui-button--text" type="button" data-action="delete">删除</button></td></tr>
-                    <tr><td>显示名称</td><td>display_name</td><td>列表中展示的配置项名称</td><td style="background-color: rgb(202, 88, 88)">maintainer-a</td><td style="width: 210px">2026-01-16 14:20:00</td><td><button class="ui-button ui-button--text" type="button" data-action="edit">编辑</button>　<button class="ui-button ui-button--text" type="button" data-action="delete">删除</button></td></tr>
-                    <tr><td>自动归档</td><td>auto_archive</td><td>是否自动归档已完成记录，0 表示关闭，1 表示开启</td><td>maintainer-c</td><td>2026-01-17 09:00:00</td><td><button class="ui-button ui-button--text" type="button" data-action="edit">编辑</button>　<button class="ui-button ui-button--text" type="button" data-action="delete">删除</button></td></tr>
-                    <tr><td>最大重试次数</td><td>max_retry_count</td><td>任务失败后的最大重试次数</td><td>maintainer-b</td><td>2026-01-17 11:45:00</td><td><button class="ui-button ui-button--text" type="button" data-action="edit">编辑</button>　<button class="ui-button ui-button--text" type="button" data-action="delete">删除</button></td></tr>
-                    <tr><td>语言偏好</td><td>locale</td><td>界面默认语言设置</td><td>maintainer-a</td><td>2026-01-18 16:30:00</td><td><button class="ui-button ui-button--text" type="button" data-action="edit">编辑</button>　<button class="ui-button ui-button--text" type="button" data-action="delete">删除</button></td></tr>
-                    <tr><td>页面主题</td><td>theme_mode</td><td>界面主题，可选 light 或 dark</td><td>maintainer-c</td><td>2026-01-19 08:40:00</td><td><button class="ui-button ui-button--text" type="button" data-action="edit">编辑</button>　<button class="ui-button ui-button--text" type="button" data-action="delete">删除</button></td></tr>
+                    <tr><td>Default Timeout</td><td>default_timeout</td><td>Default task timeout, in minutes</td><td>maintainer-b</td><td>2026-01-16 10:15:00</td><td><button class="ui-button ui-button--text" type="button" data-action="edit">Edit</button>　<button class="ui-button ui-button--text" type="button" data-action="delete">Delete</button></td></tr>
+                    <tr><td>Display Name</td><td>display_name</td><td>Configuration item name shown in lists</td><td>maintainer-a</td><td style="width: 210px">2026-01-16 14:20:00</td><td><button class="ui-button ui-button--text" type="button" data-action="edit">Edit</button>　<button class="ui-button ui-button--text" type="button" data-action="delete">Delete</button></td></tr>
+                    <tr><td>Auto Archive</td><td>auto_archive</td><td>Whether to auto-archive completed records; 0 means off, 1 means on</td><td>maintainer-c</td><td>2026-01-17 09:00:00</td><td><button class="ui-button ui-button--text" type="button" data-action="edit">Edit</button>　<button class="ui-button ui-button--text" type="button" data-action="delete">Delete</button></td></tr>
+                    <tr><td>Max Retry Count</td><td>max_retry_count</td><td>Maximum retry count after a task failure</td><td>maintainer-b</td><td>2026-01-17 11:45:00</td><td><button class="ui-button ui-button--text" type="button" data-action="edit">Edit</button>　<button class="ui-button ui-button--text" type="button" data-action="delete">Delete</button></td></tr>
+                    <tr><td>Language Preference</td><td>locale</td><td>Default interface language setting</td><td>maintainer-a</td><td>2026-01-18 16:30:00</td><td><button class="ui-button ui-button--text" type="button" data-action="edit">Edit</button>　<button class="ui-button ui-button--text" type="button" data-action="delete">Delete</button></td></tr>
+                    <tr><td>Page Theme</td><td>theme_mode</td><td>Interface theme; choose light or dark</td><td>maintainer-c</td><td>2026-01-19 08:40:00</td><td><button class="ui-button ui-button--text" type="button" data-action="edit">Edit</button>　<button class="ui-button ui-button--text" type="button" data-action="delete">Delete</button></td></tr>
                   </tbody>
                 </table>
               </div>
               <div class="ui-pagination">
-                <span>第 1-8 条/总共 13 条</span><span>‹</span><span class="ui-page-number">1</span><span>2</span><span>›</span><span>跳至</span><input class="ui-input" aria-label="跳转页码" style="width:48px"><span>页</span>
+                <span>Items 1-8 of 13</span><span>‹</span><span class="ui-page-number">1</span><span>2</span><span>›</span><span>Go to</span><input class="ui-input" aria-label="Jump to page" style="width:48px"><span>page</span>
               </div>
             </section>
           </article>
@@ -115,53 +115,53 @@
       </div>
     </div>
 
-    <!-- 新建配置项 Modal。 -->
+    <!-- New configuration item modal. -->
     <div class="ui-overlay" id="createModal" role="dialog" aria-modal="true" aria-labelledby="createTitle" aria-hidden="true" hidden>
       <div class="ui-modal">
-        <div class="ui-layer-head"><strong id="createTitle">新建</strong><button class="ui-close" type="button" data-action="close" aria-label="关闭">×</button></div>
+        <div class="ui-layer-head"><strong id="createTitle">New</strong><button class="ui-close" type="button" data-action="close" aria-label="Close">×</button></div>
         <div class="ui-layer-body" id="createForm">
-          <label class="ui-field"><span class="ui-field-label"><span class="ui-required" aria-hidden="true">*</span> 名称：</span><input class="ui-input" id="createName" maxlength="36" placeholder="请输入不超过36字符"></label>
-          <label class="ui-field"><span class="ui-field-label"><span class="ui-required" aria-hidden="true">*</span> 编码：</span><input class="ui-input" id="createCode" maxlength="36" placeholder="请输入不超过36字符"></label>
-          <label class="ui-field"><span class="ui-field-label">描述：</span><textarea class="ui-input" id="createDescription" placeholder="请输入描述"></textarea></label>
+          <label class="ui-field"><span class="ui-field-label"><span class="ui-required" aria-hidden="true">*</span> Name:</span><input class="ui-input" id="createName" maxlength="36" placeholder="Up to 36 characters"></label>
+          <label class="ui-field"><span class="ui-field-label"><span class="ui-required" aria-hidden="true">*</span> Code:</span><input class="ui-input" id="createCode" maxlength="36" placeholder="Up to 36 characters"></label>
+          <label class="ui-field"><span class="ui-field-label">Description:</span><textarea class="ui-input" id="createDescription" placeholder="Enter a description"></textarea></label>
         </div>
-        <div class="ui-layer-foot"><button class="ui-button" type="button" data-action="close">取消</button><button class="ui-button ui-button--primary" type="button" data-action="save">确定</button></div>
+        <div class="ui-layer-foot"><button class="ui-button" type="button" data-action="close">Cancel</button><button class="ui-button ui-button--primary" type="button" data-action="save">OK</button></div>
       </div>
     </div>
 
-    <!-- 编辑配置项 Modal。 -->
+    <!-- Edit configuration item modal. -->
     <div class="ui-overlay" id="editModal" role="dialog" aria-modal="true" aria-labelledby="editTitle" aria-hidden="true" hidden>
       <div class="ui-modal">
-        <div class="ui-layer-head"><strong id="editTitle">编辑</strong><button class="ui-close" type="button" data-action="close" aria-label="关闭">×</button></div>
+        <div class="ui-layer-head"><strong id="editTitle">Edit</strong><button class="ui-close" type="button" data-action="close" aria-label="Close">×</button></div>
         <div class="ui-layer-body" id="editForm">
-          <label class="ui-field"><span class="ui-field-label"><span class="ui-required" aria-hidden="true">*</span> 名称：</span><input class="ui-input" value="通知开关"></label>
-          <label class="ui-field"><span class="ui-field-label"><span class="ui-required" aria-hidden="true">*</span> 编码：</span><input class="ui-input" value="notification_enabled"></label>
-          <label class="ui-field"><span class="ui-field-label">描述：</span><textarea class="ui-input">是否启用通知，0 表示关闭，1 表示开启</textarea></label>
+          <label class="ui-field"><span class="ui-field-label"><span class="ui-required" aria-hidden="true">*</span> Name:</span><input class="ui-input" value="Notification Switch"></label>
+          <label class="ui-field"><span class="ui-field-label"><span class="ui-required" aria-hidden="true">*</span> Code:</span><input class="ui-input" value="notification_enabled"></label>
+          <label class="ui-field"><span class="ui-field-label">Description:</span><textarea class="ui-input">Whether notifications are enabled; 0 means off, 1 means on</textarea></label>
         </div>
-        <div class="ui-layer-foot"><button class="ui-button" type="button" data-action="close">取消</button><button class="ui-button ui-button--primary" type="button" data-action="save">确定</button></div>
+        <div class="ui-layer-foot"><button class="ui-button" type="button" data-action="close">Cancel</button><button class="ui-button ui-button--primary" type="button" data-action="save">OK</button></div>
       </div>
     </div>
 
-    <!-- 项目任务中新建配置项的关联示意。 -->
+    <!-- Linking a configuration item when creating a project task. -->
     <div class="ui-overlay" id="strategyModal" role="dialog" aria-modal="true" aria-labelledby="strategyTitle" aria-hidden="true" hidden>
       <div class="ui-modal ui-modal--strategy">
-        <div class="ui-layer-head"><strong id="strategyTitle">新建</strong><button class="ui-close" type="button" data-action="close" aria-label="关闭">×</button></div>
+        <div class="ui-layer-head"><strong id="strategyTitle">New</strong><button class="ui-close" type="button" data-action="close" aria-label="Close">×</button></div>
         <div class="ui-layer-body">
           <div class="ui-field" id="strategyNameField">
-            <span class="ui-field-label"><span class="ui-required" aria-hidden="true">*</span> 名称：</span>
+            <span class="ui-field-label"><span class="ui-required" aria-hidden="true">*</span> Name:</span>
             <div class="ui-select" id="strategyNameSelect">
-              <button class="ui-select-trigger" type="button" aria-haspopup="listbox" aria-controls="strategyNameOptions" aria-expanded="false" data-action="select-toggle" data-ui-interactive><span id="strategyNameValue">请选择</span><span aria-hidden="true">⌄</span></button>
+              <button class="ui-select-trigger" type="button" aria-haspopup="listbox" aria-controls="strategyNameOptions" aria-expanded="false" data-action="select-toggle" data-ui-interactive><span id="strategyNameValue">Please select</span><span aria-hidden="true">⌄</span></button>
               <div class="ui-select-menu" id="strategyNameOptions" role="listbox">
-                <button class="ui-select-option" type="button" role="option" aria-selected="false" data-action="select-option">通知开关</button>
-                <button class="ui-select-option" type="button" role="option" aria-selected="false" data-action="select-option">默认超时时间</button>
-                <button class="ui-select-option" type="button" role="option" aria-selected="false" data-action="select-option">显示名称</button>
+                <button class="ui-select-option" type="button" role="option" aria-selected="false" data-action="select-option">Notification Switch</button>
+                <button class="ui-select-option" type="button" role="option" aria-selected="false" data-action="select-option">Default Timeout</button>
+                <button class="ui-select-option" type="button" role="option" aria-selected="false" data-action="select-option">Display Name</button>
               </div>
             </div>
           </div>
-          <label class="ui-field"><span class="ui-field-label">编码：</span><input class="ui-input" placeholder="请输入"></label>
-          <div class="ui-field"><span class="ui-field-label"><span class="ui-required" aria-hidden="true">*</span> 条件：</span><div class="ui-select" id="strategyConditionSelect"><button class="ui-select-trigger" type="button" aria-haspopup="listbox" aria-controls="strategyConditionOptions" aria-expanded="false" data-action="select-toggle"><span id="strategyConditionValue">请选择</span><span aria-hidden="true">⌄</span></button><div class="ui-select-menu" id="strategyConditionOptions" role="listbox"><button class="ui-select-option" type="button" role="option" aria-selected="false" data-action="select-option">等于</button><button class="ui-select-option" type="button" role="option" aria-selected="false" data-action="select-option">大于</button></div></div></div>
-          <label class="ui-field"><span class="ui-field-label"><span class="ui-required" aria-hidden="true">*</span> 状态：</span><input class="ui-input" placeholder="请输入"></label>
+          <label class="ui-field"><span class="ui-field-label">Code:</span><input class="ui-input" placeholder="Enter here"></label>
+          <div class="ui-field"><span class="ui-field-label"><span class="ui-required" aria-hidden="true">*</span> Condition:</span><div class="ui-select" id="strategyConditionSelect"><button class="ui-select-trigger" type="button" aria-haspopup="listbox" aria-controls="strategyConditionOptions" aria-expanded="false" data-action="select-toggle"><span id="strategyConditionValue">Please select</span><span aria-hidden="true">⌄</span></button><div class="ui-select-menu" id="strategyConditionOptions" role="listbox"><button class="ui-select-option" type="button" role="option" aria-selected="false" data-action="select-option">Equals</button><button class="ui-select-option" type="button" role="option" aria-selected="false" data-action="select-option">Greater than</button></div></div></div>
+          <label class="ui-field"><span class="ui-field-label"><span class="ui-required" aria-hidden="true">*</span> Status:</span><input class="ui-input" placeholder="Enter here"></label>
         </div>
-        <div class="ui-layer-foot"><button class="ui-button" type="button" data-action="close">取消</button><button class="ui-button ui-button--primary" type="button" data-action="save">确定</button></div>
+        <div class="ui-layer-foot"><button class="ui-button" type="button" data-action="close">Cancel</button><button class="ui-button ui-button--primary" type="button" data-action="save">OK</button></div>
       </div>
     </div>
   </div>

--- a/examples/minimal-notes/prototype/notes.snapshot.js
+++ b/examples/minimal-notes/prototype/notes.snapshot.js
@@ -20,9 +20,11 @@ window.__PROTOTYPE_NOTES__ = {
   "activeScenario": "base",
   "scenarios": {
     "base": {
+      "label": "List",
       "state": {}
     },
     "create": {
+      "label": "Create",
       "extends": "base",
       "state": {
         "product": {
@@ -33,6 +35,7 @@ window.__PROTOTYPE_NOTES__ = {
       }
     },
     "edit": {
+      "label": "Edit",
       "extends": "base",
       "state": {
         "product": {
@@ -43,6 +46,7 @@ window.__PROTOTYPE_NOTES__ = {
       }
     },
     "strategy": {
+      "label": "Link",
       "extends": "base",
       "state": {
         "product": {
@@ -54,17 +58,17 @@ window.__PROTOTYPE_NOTES__ = {
     }
   },
   "header": {
-    "title": "功能说明",
-    "subtitle": "按列表、新建、编辑与任务关联状态展示"
+    "title": "Function Notes",
+    "subtitle": "Shown for list, create, edit and task-linking states"
   },
   "cards": [
     {
       "id": "note-7",
-      "title": "新说明",
-      "body": "查询过滤\n",
+      "title": "New note",
+      "body": "Filter by query",
       "target": {
         "anchor": "filterCode",
-        "label": "配置项编码"
+        "label": "Configuration item code"
       },
       "when": {
         "product.layers": [],
@@ -77,11 +81,11 @@ window.__PROTOTYPE_NOTES__ = {
         "product.page": "list",
         "product.layers": []
       },
-      "title": "配置项查询",
-      "body": "可按配置项名称、编码筛选；重置清空当前筛选值，查询刷新列表结果。",
+      "title": "Configuration item search",
+      "body": "Filter by configuration item name or code; Reset clears the current filters, Search refreshes the list.",
       "target": {
         "anchor": "filterArea",
-        "label": "配置项查询"
+        "label": "Configuration item search"
       }
     },
     {
@@ -90,11 +94,11 @@ window.__PROTOTYPE_NOTES__ = {
         "product.page": "list",
         "product.layers": []
       },
-      "title": "维护列表",
-      "body": "列表展示名称、编码、描述、创建者和创建时间，并提供编辑、删除操作。",
+      "title": "Maintenance list",
+      "body": "The list shows name, code, description, creator and creation time, with edit and delete actions.",
       "target": {
         "anchor": "tableArea",
-        "label": "配置项列表"
+        "label": "Configuration item list"
       }
     },
     {
@@ -105,11 +109,11 @@ window.__PROTOTYPE_NOTES__ = {
           "create"
         ]
       },
-      "title": "新建字段",
-      "body": "名称、编码限制不超过 36 个字符；提交后新增配置项。",
+      "title": "Create fields",
+      "body": "Name and code are limited to 36 characters; submitting creates a new configuration item.",
       "target": {
         "anchor": "createForm",
-        "label": "新建配置项表单"
+        "label": "New configuration item form"
       }
     },
     {
@@ -120,11 +124,11 @@ window.__PROTOTYPE_NOTES__ = {
           "edit"
         ]
       },
-      "title": "编辑字段",
-      "body": "编辑时回显已有名称、编码和描述，确认后保存修改。",
+      "title": "Edit fields",
+      "body": "Editing pre-fills the existing name, code and description; confirm to save the changes.",
       "target": {
         "anchor": "editForm",
-        "label": "编辑配置项表单"
+        "label": "Edit configuration item form"
       }
     },
     {
@@ -135,11 +139,11 @@ window.__PROTOTYPE_NOTES__ = {
           "strategy"
         ]
       },
-      "title": "任务关联配置项",
-      "body": "项目任务新建配置项时，名称不再自由输入，改为下拉选择配置项维护列表中的名称。",
+      "title": "Link configuration item to task",
+      "body": "When creating a configuration item from a project task, the name is no longer free-text; it becomes a dropdown of names from the configuration item maintenance list.",
       "target": {
         "anchor": "strategyNameField",
-        "label": "任务配置项名称选择"
+        "label": "Task configuration item name select"
       }
     },
     {
@@ -148,11 +152,11 @@ window.__PROTOTYPE_NOTES__ = {
         "product.page": "list",
         "product.layers": []
       },
-      "title": "新增菜单入口",
-      "body": "在系统设置下增加“配置项”菜单，进入统一维护列表。",
+      "title": "New menu entry",
+      "body": "Add a Configuration Items menu under System Settings to enter the unified maintenance list.",
       "target": {
         "anchor": "menuConfig",
-        "label": "配置项"
+        "label": "Configuration Items"
       }
     }
   ]

--- a/examples/minimal-notes/prototype/prototype.js
+++ b/examples/minimal-notes/prototype/prototype.js
@@ -69,7 +69,7 @@
       const select = product.selects[id];
       elements.root.classList.toggle('is-open', select.open);
       elements.trigger.setAttribute('aria-expanded', String(select.open));
-      elements.value.textContent = select.value || '请选择';
+      elements.value.textContent = select.value || 'Please select';
       elements.options.forEach((option) => {
         option.setAttribute('aria-selected', String(Boolean(select.value) && option.textContent.trim() === select.value));
       });
@@ -153,7 +153,7 @@
     document.getElementById('filterName').value = '';
     document.getElementById('filterCode').value = '';
   });
-  document.getElementById('queryButton').addEventListener('click', () => showToast('查询完成'));
+  document.getElementById('queryButton').addEventListener('click', () => showToast('Search complete'));
 
   document.addEventListener('click', (event) => {
     const actionTarget = event.target.closest('[data-action]');
@@ -164,11 +164,11 @@
 
     const action = actionTarget.dataset.action;
     if (action === 'edit') activateLayerScenario('edit');
-    if (action === 'delete' && window.confirm('确认删除该配置项吗？')) showToast('删除成功');
+    if (action === 'delete' && window.confirm('Delete this configuration item?')) showToast('Deleted');
     if (action === 'close') activateLayerScenario('base');
     if (action === 'save') {
       activateLayerScenario('base');
-      showToast('保存成功');
+      showToast('Saved');
     }
     if (action === 'select-toggle') {
       const id = findSelectId(actionTarget);

--- a/examples/minimal-notes/prototype/viewer.js
+++ b/examples/minimal-notes/prototype/viewer.js
@@ -82,7 +82,7 @@
     state.preview.className = 'pn-preview';
     state.notes = document.createElement('aside');
     state.notes.className = 'pn-notes';
-    state.notes.setAttribute('aria-label', '功能说明');
+    state.notes.setAttribute('aria-label', 'Function notes');
     state.cards = document.createElement('div');
     state.cards.className = 'pn-cards';
     state.actions = document.createElement('div');
@@ -175,8 +175,8 @@
       btn = document.createElement('button');
       btn.className = 'pn-scene-switch';
       btn.type = 'button';
-      btn.title = '切换场景';
-      btn.setAttribute('aria-label', '切换场景');
+      btn.title = 'Switch scenario';
+      btn.setAttribute('aria-label', 'Switch scenario');
       btn.innerHTML = sceneSwitchIcon + '<span class="pn-scene-switch-label"></span>';
       btn.addEventListener('click', cycleScenario);
       start.insertBefore(btn, start.firstChild);
@@ -191,7 +191,7 @@
       labelEl = btn.querySelector('.pn-scene-switch-label');
     }
     labelEl.textContent = label;
-    btn.title = '切换场景（当前：' + label + '）';
+    btn.title = 'Switch scenario (current: ' + label + ')';
     syncPanelActions();
   }
 
@@ -201,12 +201,12 @@
     var toggle = document.createElement('button');
     toggle.className = 'pn-toggle';
     toggle.type = 'button';
-    toggle.title = '隐藏说明';
+    toggle.title = 'Hide notes';
     toggle.setAttribute('aria-expanded', 'true');
     toggle.textContent = '››';
     toggle.addEventListener('click', function () {
       var collapsed = state.page.classList.toggle('pn-collapsed');
-      toggle.title = collapsed ? '显示说明' : '隐藏说明';
+      toggle.title = collapsed ? 'Show notes' : 'Hide notes';
       toggle.setAttribute('aria-expanded', String(!collapsed));
       toggle.textContent = collapsed ? '‹‹' : '››';
       scheduleDraw();
@@ -217,11 +217,11 @@
     var mobile = document.createElement('button');
     mobile.className = 'pn-mobile-toggle';
     mobile.type = 'button';
-    mobile.textContent = '查看说明';
+    mobile.textContent = 'View notes';
     mobile.setAttribute('aria-pressed', 'false');
     mobile.addEventListener('click', function () {
       var visible = state.page.classList.toggle('pn-notes-visible');
-      mobile.textContent = visible ? '查看界面' : '查看说明';
+      mobile.textContent = visible ? 'View page' : 'View notes';
       mobile.setAttribute('aria-pressed', String(visible));
     });
     document.body.insertBefore(mobile, beforeNode);
@@ -236,7 +236,7 @@
       var head = document.createElement('div');
       head.className = 'pn-head';
       head.innerHTML = '<strong></strong><span></span>';
-      head.querySelector('strong').textContent = data.header && data.header.title || '功能说明';
+      head.querySelector('strong').textContent = data.header && data.header.title || 'Function notes';
       head.querySelector('span').textContent = data.header && data.header.subtitle || '';
       state.notes.appendChild(head);
 
@@ -248,7 +248,7 @@
         article.dataset.noteId = card.id;
         article.innerHTML = '<div class="pn-card-title"><span class="pn-index"></span><span class="pn-title-text"></span></div><p></p>';
         article.querySelector('.pn-index').textContent = String(index + 1);
-        article.querySelector('.pn-title-text').textContent = card.title || '未命名说明';
+        article.querySelector('.pn-title-text').textContent = card.title || 'Untitled note';
         article.querySelector('p').textContent = card.body || '';
         bindHighlight(article, card.id);
         state.cards.appendChild(article);
@@ -416,7 +416,7 @@
     state.page.classList.add('pn-collapsed');
     var toggle = state.actions.querySelector('.pn-toggle');
     if (toggle) {
-      toggle.title = '显示说明';
+      toggle.title = 'Show notes';
       toggle.setAttribute('aria-expanded', 'false');
       toggle.textContent = '‹‹';
     }
@@ -468,16 +468,16 @@
   function init() {
     if (state.page) return;
     if (!window.PrototypeViewers) {
-      console.error('[prototype-notes] 缺少 PrototypeViewers 状态内核，请先加载 client/core/state.js。');
+      console.error('[prototype-notes] missing PrototypeViewers state core; load client/core/state.js first.');
       return;
     }
     if (!window.PrototypeNotesModel) {
-      console.error('[prototype-notes] 缺少 PrototypeNotesModel，请先加载 client/notes/model.js。');
+      console.error('[prototype-notes] missing PrototypeNotesModel; load client/notes/model.js first.');
       return;
     }
     var data = window.__PROTOTYPE_NOTES__;
     if (!data || !Array.isArray(data.cards)) {
-      console.error('[prototype-notes] 缺少有效的 window.__PROTOTYPE_NOTES__ 数据。');
+      console.error('[prototype-notes] missing valid window.__PROTOTYPE_NOTES__ data.');
       return;
     }
     state.data = data;

--- a/skills/html-prototype-build/runtime/author/shell/index.js
+++ b/skills/html-prototype-build/runtime/author/shell/index.js
@@ -172,8 +172,8 @@
     launch.type = 'button';
     launch.id = 'at-launch';
     launch.className = 'at-launch at-ui';
-    launch.title = '原型工具';
-    launch.setAttribute('aria-label', '原型工具');
+    launch.title = 'Prototype Tools';
+    launch.setAttribute('aria-label', 'Prototype Tools');
     launch.innerHTML =
       '<svg class="at-launch-icon" viewBox="0 0 16 16" aria-hidden="true">' +
       '<path d="M11.2 2.2a2.4 2.4 0 0 0-2.2 3.8L4.2 10.8a1.5 1.5 0 1 0 2.1 2.1l4.8-4.8a2.4 2.4 0 0 0 3.8-2.2" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>' +
@@ -184,8 +184,8 @@
     panel.innerHTML =
       '<div class="at-panel-open">' +
       '  <div class="at-panel-head" id="at-head">' +
-      '    <span class="at-panel-title">原型工具</span>' +
-      '    <button type="button" class="at-iconbtn" id="at-close" title="关闭">×</button>' +
+      '    <span class="at-panel-title">Prototype Tools</span>' +
+      '    <button type="button" class="at-iconbtn" id="at-close" title="Close">×</button>' +
       '  </div>' +
       '  <div class="at-tabs">' +
       '    <button type="button" class="at-tab is-active" data-tab="edit">Edit</button>' +
@@ -196,9 +196,9 @@
       '    <div class="at-tool-pane" data-pane="mark"></div>' +
       '  </div>' +
       '  <div class="at-dirty-bar" id="at-dirty">' +
-      '    <span>当前有未保存的修改</span>' +
-      '    <button type="button" class="at-btn" id="at-dirty-keep">继续编辑</button>' +
-      '    <button type="button" class="at-btn primary" id="at-dirty-drop">放弃修改</button>' +
+      '    <span>You have unsaved changes</span>' +
+      '    <button type="button" class="at-btn" id="at-dirty-keep">Keep editing</button>' +
+      '    <button type="button" class="at-btn primary" id="at-dirty-drop">Discard changes</button>' +
       '  </div>' +
       '</div>';
 

--- a/skills/html-prototype-build/runtime/author/tools/direct-edit/panel.js
+++ b/skills/html-prototype-build/runtime/author/tools/direct-edit/panel.js
@@ -10,7 +10,7 @@
 
   function sourceLabel(row) {
     var kind = row.sourceKind || (row.dirty ? 'dirty' : row.overridden ? 'inline' : 'class');
-    var text = row.sourceLabel || (kind === 'inline' ? 'Inline' : '样式表');
+    var text = row.sourceLabel || (kind === 'inline' ? 'Inline' : 'Stylesheet');
     var title = row.sourceTitle ? ' title="' + esc(row.sourceTitle) + '"' : '';
     var cls = 'at-src';
     if (kind === 'dirty') cls += ' is-dirty';
@@ -62,7 +62,7 @@
     if (mixed && first) {
       return sourceLabel({
         sourceKind: first.sourceKind,
-        sourceLabel: '混合',
+        sourceLabel: 'Mixed',
         sourceTitle: props.map(function (prop) {
           var row = session.rows[prop];
           return prop + ': ' + ((row && row.sourceLabel) || '');
@@ -77,14 +77,14 @@
     if (field.kind === 'align') {
       return '<select data-prop="' + field.key + '">' +
         ['', 'left', 'center', 'right', 'justify'].map(function (opt) {
-          return '<option value="' + opt + '"' + (value === opt ? ' selected' : '') + '>' + (opt || '默认') + '</option>';
+          return '<option value="' + opt + '"' + (value === opt ? ' selected' : '') + '>' + (opt || 'Default') + '</option>';
         }).join('') +
         '</select>';
     }
     if (field.kind === 'color') return colorControl(field.key, row);
     if (field.kind === 'length') return lengthControl(field.key, row);
     return '<input data-prop="' + field.key + '" value="' + esc(value) + '"' +
-      (field.kind === 'text' && !session.canEditText ? ' disabled placeholder="含子节点，请用 Mark"' : '') + '>';
+      (field.kind === 'text' && !session.canEditText ? ' disabled placeholder="Has child nodes, use Mark"' : '') + '>';
   }
 
   function borderMeta(field, session) {
@@ -93,8 +93,8 @@
     var options = ['none', 'solid', 'dashed'];
     if (styleValue && options.indexOf(styleValue) < 0) options.unshift(styleValue);
     return '<div class="at-border-meta">' +
-      '<label class="at-border-extra">颜色' + colorControl(field.color, session.rows[field.color]) + '</label>' +
-      '<label class="at-border-extra">线型<select data-prop="' + field.style + '">' +
+      '<label class="at-border-extra">Color' + colorControl(field.color, session.rows[field.color]) + '</label>' +
+      '<label class="at-border-extra">Style<select data-prop="' + field.style + '">' +
       options.map(function (opt) {
         return '<option value="' + esc(opt) + '"' + (styleValue === opt ? ' selected' : '') + '>' + esc(opt) + '</option>';
       }).join('') +
@@ -110,12 +110,12 @@
     if (!session) {
       container.innerHTML =
         '<div class="at-edit-body">' +
-        '  <div class="at-edit-empty">按住 <kbd>' + esc(clickModifierLabel()) + '</kbd> 点击页面元素以选中。<br>普通点击保持页面交互。</div>' +
+        '  <div class="at-edit-empty">Hold <kbd>' + esc(clickModifierLabel()) + '</kbd> and click a page element to select it.<br>Normal clicks keep the page interactive.</div>' +
         '</div>' +
         '<div class="at-edit-foot">' +
-        '  <button type="button" class="at-btn" data-act="cancel" disabled>取消</button>' +
-        '  <button type="button" class="at-btn" data-act="reset" disabled>重置该元素</button>' +
-        '  <button type="button" class="at-btn primary" data-act="save" disabled>保存</button>' +
+        '  <button type="button" class="at-btn" data-act="cancel" disabled>Cancel</button>' +
+        '  <button type="button" class="at-btn" data-act="reset" disabled>Reset element</button>' +
+        '  <button type="button" class="at-btn primary" data-act="save" disabled>Save</button>' +
         '</div>';
       return;
     }
@@ -143,7 +143,7 @@
             return '<div class="at-edit-row">' +
               '<label>' + esc(field.label) + '</label>' +
               fieldControl(field, null, session) +
-              '<span class="at-src">' + (session.canEditText ? 'Text' : '禁用') + '</span>' +
+              '<span class="at-src">' + (session.canEditText ? 'Text' : 'Disabled') + '</span>' +
               '<span></span></div>';
           }
           if (field.kind === 'box' || field.kind === 'border') {
@@ -170,9 +170,9 @@
     container.innerHTML =
       '<div class="at-edit-body">' + identity + fieldsHtml + '</div>' +
       '<div class="at-edit-foot">' +
-      '  <button type="button" class="at-btn" data-act="cancel"' + (dirty ? '' : ' disabled') + '>取消</button>' +
-      '  <button type="button" class="at-btn" data-act="reset">重置该元素</button>' +
-      '  <button type="button" class="at-btn primary" data-act="save"' + (dirty ? '' : ' disabled') + '>保存</button>' +
+      '  <button type="button" class="at-btn" data-act="cancel"' + (dirty ? '' : ' disabled') + '>Cancel</button>' +
+      '  <button type="button" class="at-btn" data-act="reset">Reset element</button>' +
+      '  <button type="button" class="at-btn primary" data-act="save"' + (dirty ? '' : ' disabled') + '>Save</button>' +
       '</div>';
   }
 

--- a/skills/html-prototype-build/runtime/author/tools/direct-edit/style-model.js
+++ b/skills/html-prototype-build/runtime/author/tools/direct-edit/style-model.js
@@ -4,10 +4,10 @@
 
   var COLOR_PROPS = { color: true, 'background-color': true, 'border-color': true };
   var BOX_SIDES = [
-    { suffix: 'top', label: '上' },
-    { suffix: 'right', label: '右' },
-    { suffix: 'bottom', label: '下' },
-    { suffix: 'left', label: '左' }
+    { suffix: 'top', label: 'Top' },
+    { suffix: 'right', label: 'Right' },
+    { suffix: 'bottom', label: 'Bottom' },
+    { suffix: 'left', label: 'Left' }
   ];
   function boxSides(prefix) {
     return BOX_SIDES.map(function (side) {
@@ -15,21 +15,21 @@
     });
   }
   var FIELDS = [
-    { group: '内容', key: 'text', label: '文本', kind: 'text' },
-    { group: '尺寸', key: 'width', label: '宽度', kind: 'length' },
-    { group: '尺寸', key: 'height', label: '高度', kind: 'length' },
-    { group: '间距', key: 'padding', label: 'Padding', kind: 'box', sides: boxSides('padding') },
-    { group: '间距', key: 'margin', label: 'Margin', kind: 'box', sides: boxSides('margin') },
-    { group: '间距', key: 'gap', label: 'Gap', kind: 'length' },
-    { group: '文字', key: 'font-size', label: '字号', kind: 'length' },
-    { group: '文字', key: 'font-weight', label: '字重', kind: 'css' },
-    { group: '文字', key: 'color', label: '颜色', kind: 'color' },
-    { group: '文字', key: 'text-align', label: '对齐', kind: 'align' },
-    { group: '外观', key: 'background-color', label: '背景', kind: 'color' },
+    { group: 'Content', key: 'text', label: 'Text', kind: 'text' },
+    { group: 'Size', key: 'width', label: 'Width', kind: 'length' },
+    { group: 'Size', key: 'height', label: 'Height', kind: 'length' },
+    { group: 'Spacing', key: 'padding', label: 'Padding', kind: 'box', sides: boxSides('padding') },
+    { group: 'Spacing', key: 'margin', label: 'Margin', kind: 'box', sides: boxSides('margin') },
+    { group: 'Spacing', key: 'gap', label: 'Gap', kind: 'length' },
+    { group: 'Typography', key: 'font-size', label: 'Font size', kind: 'length' },
+    { group: 'Typography', key: 'font-weight', label: 'Font weight', kind: 'css' },
+    { group: 'Typography', key: 'color', label: 'Color', kind: 'color' },
+    { group: 'Typography', key: 'text-align', label: 'Align', kind: 'align' },
+    { group: 'Appearance', key: 'background-color', label: 'Background', kind: 'color' },
     {
-      group: '外观',
+      group: 'Appearance',
       key: 'border',
-      label: '边框',
+      label: 'Border',
       kind: 'border',
       sides: BOX_SIDES.map(function (side) {
         return { key: 'border-' + side.suffix + '-width', label: side.label };
@@ -38,15 +38,15 @@
       style: 'border-style'
     },
     {
-      group: '外观',
+      group: 'Appearance',
       key: 'border-radius',
-      label: '圆角',
+      label: 'Border radius',
       kind: 'box',
       sides: [
-        { key: 'border-top-left-radius', label: '左上' },
-        { key: 'border-top-right-radius', label: '右上' },
-        { key: 'border-bottom-right-radius', label: '右下' },
-        { key: 'border-bottom-left-radius', label: '左下' }
+        { key: 'border-top-left-radius', label: 'Top left' },
+        { key: 'border-top-right-radius', label: 'Top right' },
+        { key: 'border-bottom-right-radius', label: 'Bottom right' },
+        { key: 'border-bottom-left-radius', label: 'Bottom left' }
       ]
     }
   ];
@@ -195,7 +195,7 @@
     if (el.id && selector.indexOf('#' + el.id) !== -1) return '#' + el.id;
     var first = selector.match(/\.(-?[_a-zA-Z]+[_a-zA-Z0-9-]*)/);
     if (first) return '.' + first[1];
-    return selector.replace(/\s+/g, ' ').trim().slice(0, 48) || '样式表';
+    return selector.replace(/\s+/g, ' ').trim().slice(0, 48) || 'Stylesheet';
   }
 
   function collectRules(list, out) {
@@ -253,19 +253,19 @@
     var inlineValue = readInline(el, prop);
     var inlineImportant = !!(el.style && typeof el.style.getPropertyPriority === 'function' && el.style.getPropertyPriority(prop) === 'important');
     if (inlineValue && !(found && found.important && !inlineImportant)) {
-      return { kind: 'inline', label: 'Inline', title: '元素 style 属性' };
+      return { kind: 'inline', label: 'Inline', title: 'Element style attribute' };
     }
     if (found) return { kind: 'class', label: found.label, title: found.selector + (found.important ? ' !important' : '') };
     if (INHERITED[prop]) {
       cur = el.parentElement;
       while (cur && cur !== document.documentElement) {
-        if (readInline(cur, prop)) return { kind: 'inherit', label: '继承 Inline', title: '继承自父元素 inline style' };
+        if (readInline(cur, prop)) return { kind: 'inherit', label: 'Inherited Inline', title: 'Inherited from parent element inline style' };
         found = findOnElement(cur, prop);
-        if (found) return { kind: 'inherit', label: '继承 ' + found.label, title: found.selector };
+        if (found) return { kind: 'inherit', label: 'Inherited ' + found.label, title: found.selector };
         cur = cur.parentElement;
       }
     }
-    return { kind: 'ua', label: '浏览器默认', title: 'User Agent / 未命中样式规则' };
+    return { kind: 'ua', label: 'Browser default', title: 'User Agent / no matching style rule' };
   }
 
   function readComputed(el, prop) {
@@ -376,8 +376,8 @@
         row.displayValue = typed;
         row.dirty = typed !== row.baselineDisplay || !!row.originalInline;
         row.sourceKind = 'dirty';
-        row.sourceLabel = '未保存';
-        row.sourceTitle = '仅预览，尚未写入源文件';
+        row.sourceLabel = 'Unsaved';
+        row.sourceTitle = 'Preview only; not written to the source file yet';
         return;
       }
       var cssValue = LENGTH_PROPS[prop] ? cssFromLengthInput(row, typed) : typed;
@@ -390,8 +390,8 @@
       row.dirty = current !== row.originalInline || typed !== row.baselineDisplay;
       if (row.dirty) {
         row.sourceKind = 'dirty';
-        row.sourceLabel = '未保存';
-        row.sourceTitle = '仅预览，尚未写入源文件';
+        row.sourceLabel = 'Unsaved';
+        row.sourceTitle = 'Preview only; not written to the source file yet';
       }
     }
 
@@ -406,8 +406,8 @@
         row.displayValue = shown.displayValue;
         row.unit = shown.unit;
         row.sourceKind = 'dirty';
-        row.sourceLabel = '未保存';
-        row.sourceTitle = '仅预览，尚未写入源文件';
+        row.sourceLabel = 'Unsaved';
+        row.sourceTitle = 'Preview only; not written to the source file yet';
       }
     }
 

--- a/skills/html-prototype-build/runtime/author/tools/mark/index.js
+++ b/skills/html-prototype-build/runtime/author/tools/mark/index.js
@@ -96,9 +96,9 @@
     notePop.innerHTML =
       '<div class="mm-note-pop-head"><span><b>#' + ann.id + '</b> · ' + esc(ann.label) + '</span>' +
       '<span class="mm-np-text">' + (ann.text ? esc(ann.text) : '') + '</span></div>' +
-      '<textarea placeholder="这里需要改什么？（可选）"></textarea>' +
-      '<div class="mm-note-pop-hint"><span><kbd>↵</kbd> 保存 · <kbd>⇧↵</kbd> 换行 · <kbd>Esc</kbd> 关闭</span>' +
-      '<span>' + (ann.note ? '编辑中' : '新建') + '</span></div>';
+      '<textarea placeholder="What needs to change here? (optional)"></textarea>' +
+      '<div class="mm-note-pop-hint"><span><kbd>↵</kbd> Save · <kbd>⇧↵</kbd> New line · <kbd>Esc</kbd> Close</span>' +
+      '<span>' + (ann.note ? 'Editing' : 'New') + '</span></div>';
     document.body.appendChild(notePop);
 
     var pinRect = ann.pinEl.getBoundingClientRect();
@@ -213,7 +213,7 @@
     nextId = 1;
     render();
     persist();
-    toast('已清空 ' + clearedCount + ' 条标注');
+    toast('Cleared ' + clearedCount + ' annotation' + (clearedCount > 1 ? 's' : ''));
   }
 
   function render() {
@@ -221,7 +221,7 @@
     var list = container.querySelector('#mm-list');
     if (!list) return;
     if (!annotations.length) {
-      list.innerHTML = '<div class="mm-empty">按住 <kbd>' + esc(clickModifierLabel()) + '</kbd> 点击页面元素即可落下 pin。<br><kbd>M</kbd> 打开本 Tab · <kbd>⌫</kbd> 删除上一条</div>';
+      list.innerHTML = '<div class="mm-empty">Hold <kbd>' + esc(clickModifierLabel()) + '</kbd> and click a page element to drop a pin.<br><kbd>M</kbd> opens this tab · <kbd>⌫</kbd> deletes the last one</div>';
       return;
     }
     list.innerHTML = annotations.map(function (ann, index) {
@@ -229,10 +229,10 @@
       return '<div class="mm-item ' + (hasNote ? 'has-note' : '') + '" data-id="' + ann.id + '">' +
         '<div class="mm-item-num">' + (index + 1) + '</div>' +
         '<div class="mm-item-body">' +
-        (hasNote ? '<div class="mm-item-note">' + esc(ann.note) + '</div>' : '<div class="mm-item-note-empty">暂无反馈 · 点击补充</div>') +
+        (hasNote ? '<div class="mm-item-note">' + esc(ann.note) + '</div>' : '<div class="mm-item-note-empty">No feedback yet · click to add</div>') +
         '<div class="mm-item-meta"><b>' + esc(ann.label) + '</b>' + (ann.text ? ' · ' + esc(ann.text).slice(0, 50) : '') + '</div>' +
         '</div>' +
-        '<button class="mm-item-del" data-del="' + ann.id + '" title="删除">×</button>' +
+        '<button class="mm-item-del" data-del="' + ann.id + '" title="Delete">×</button>' +
         '</div>';
     }).join('');
     list.querySelectorAll('.mm-item').forEach(function (item) {
@@ -269,7 +269,7 @@
 
   function copyAll() {
     if (!annotations.length) {
-      toast('还没有标注 — 先按住 ' + clickModifierLabel() + ' 点击打一个 pin。');
+      toast('No annotations yet — hold ' + clickModifierLabel() + ' and click to drop a pin.');
       return;
     }
     var fmt = container.querySelector('#mm-fmt').value;
@@ -305,9 +305,9 @@
       }).join('\n') + '\n\n@ ' + ctx;
     }
     navigator.clipboard.writeText(txt).then(function () {
-      toast('✓ 已复制 ' + annotations.length + ' 条标注（' + fmt.toUpperCase() + '）');
+      toast('✓ Copied ' + annotations.length + ' annotation' + (annotations.length > 1 ? 's' : '') + ' (' + fmt.toUpperCase() + ')');
     }).catch(function () {
-      toast('复制失败 — 请检查剪贴板权限。');
+      toast('Copy failed — check clipboard permissions.');
     });
   }
 
@@ -344,7 +344,7 @@
     });
     nextId = annotations.reduce(function (max, item) { return Math.max(max, item.id); }, 0) + 1;
     render();
-    if (annotations.length) toast('已从上次会话恢复 ' + annotations.length + ' 条标注');
+    if (annotations.length) toast('Restored ' + annotations.length + ' annotation' + (annotations.length > 1 ? 's' : '') + ' from the previous session');
   }
 
   function handleKey(event) {
@@ -392,12 +392,12 @@
         '<div class="mm-panel-foot mm-ui">' +
         '  <select class="mm-fmt-select" id="mm-fmt">' +
         '    <option value="md">Markdown</option>' +
-        '    <option value="txt">纯文本</option>' +
+        '    <option value="txt">Plain text</option>' +
         '    <option value="json">JSON</option>' +
-        '    <option value="ai">AI 定位</option>' +
+        '    <option value="ai">For AI</option>' +
         '  </select>' +
-        '  <button type="button" class="mm-btn" id="mm-clear">清空</button>' +
-        '  <button type="button" class="mm-btn primary" id="mm-copy">复制全部</button>' +
+        '  <button type="button" class="mm-btn" id="mm-clear">Clear</button>' +
+        '  <button type="button" class="mm-btn primary" id="mm-copy">Copy all</button>' +
         '</div>';
       container.querySelector('#mm-clear').addEventListener('click', clearAll);
       container.querySelector('#mm-copy').addEventListener('click', copyAll);

--- a/skills/html-prototype-build/runtime/client/notes/viewer.js
+++ b/skills/html-prototype-build/runtime/client/notes/viewer.js
@@ -82,7 +82,7 @@
     state.preview.className = 'pn-preview';
     state.notes = document.createElement('aside');
     state.notes.className = 'pn-notes';
-    state.notes.setAttribute('aria-label', '功能说明');
+    state.notes.setAttribute('aria-label', 'Function notes');
     state.cards = document.createElement('div');
     state.cards.className = 'pn-cards';
     state.actions = document.createElement('div');
@@ -175,8 +175,8 @@
       btn = document.createElement('button');
       btn.className = 'pn-scene-switch';
       btn.type = 'button';
-      btn.title = '切换场景';
-      btn.setAttribute('aria-label', '切换场景');
+      btn.title = 'Switch scenario';
+      btn.setAttribute('aria-label', 'Switch scenario');
       btn.innerHTML = sceneSwitchIcon + '<span class="pn-scene-switch-label"></span>';
       btn.addEventListener('click', cycleScenario);
       start.insertBefore(btn, start.firstChild);
@@ -191,7 +191,7 @@
       labelEl = btn.querySelector('.pn-scene-switch-label');
     }
     labelEl.textContent = label;
-    btn.title = '切换场景（当前：' + label + '）';
+    btn.title = 'Switch scenario (current: ' + label + ')';
     syncPanelActions();
   }
 
@@ -201,12 +201,12 @@
     var toggle = document.createElement('button');
     toggle.className = 'pn-toggle';
     toggle.type = 'button';
-    toggle.title = '隐藏说明';
+    toggle.title = 'Hide notes';
     toggle.setAttribute('aria-expanded', 'true');
     toggle.textContent = '››';
     toggle.addEventListener('click', function () {
       var collapsed = state.page.classList.toggle('pn-collapsed');
-      toggle.title = collapsed ? '显示说明' : '隐藏说明';
+      toggle.title = collapsed ? 'Show notes' : 'Hide notes';
       toggle.setAttribute('aria-expanded', String(!collapsed));
       toggle.textContent = collapsed ? '‹‹' : '››';
       scheduleDraw();
@@ -217,11 +217,11 @@
     var mobile = document.createElement('button');
     mobile.className = 'pn-mobile-toggle';
     mobile.type = 'button';
-    mobile.textContent = '查看说明';
+    mobile.textContent = 'View notes';
     mobile.setAttribute('aria-pressed', 'false');
     mobile.addEventListener('click', function () {
       var visible = state.page.classList.toggle('pn-notes-visible');
-      mobile.textContent = visible ? '查看界面' : '查看说明';
+      mobile.textContent = visible ? 'View page' : 'View notes';
       mobile.setAttribute('aria-pressed', String(visible));
     });
     document.body.insertBefore(mobile, beforeNode);
@@ -236,7 +236,7 @@
       var head = document.createElement('div');
       head.className = 'pn-head';
       head.innerHTML = '<strong></strong><span></span>';
-      head.querySelector('strong').textContent = data.header && data.header.title || '功能说明';
+      head.querySelector('strong').textContent = data.header && data.header.title || 'Function notes';
       head.querySelector('span').textContent = data.header && data.header.subtitle || '';
       state.notes.appendChild(head);
 
@@ -248,7 +248,7 @@
         article.dataset.noteId = card.id;
         article.innerHTML = '<div class="pn-card-title"><span class="pn-index"></span><span class="pn-title-text"></span></div><p></p>';
         article.querySelector('.pn-index').textContent = String(index + 1);
-        article.querySelector('.pn-title-text').textContent = card.title || '未命名说明';
+        article.querySelector('.pn-title-text').textContent = card.title || 'Untitled note';
         article.querySelector('p').textContent = card.body || '';
         bindHighlight(article, card.id);
         state.cards.appendChild(article);
@@ -416,7 +416,7 @@
     state.page.classList.add('pn-collapsed');
     var toggle = state.actions.querySelector('.pn-toggle');
     if (toggle) {
-      toggle.title = '显示说明';
+      toggle.title = 'Show notes';
       toggle.setAttribute('aria-expanded', 'false');
       toggle.textContent = '‹‹';
     }
@@ -468,16 +468,16 @@
   function init() {
     if (state.page) return;
     if (!window.PrototypeViewers) {
-      console.error('[prototype-notes] 缺少 PrototypeViewers 状态内核，请先加载 client/core/state.js。');
+      console.error('[prototype-notes] missing PrototypeViewers state core; load client/core/state.js first.');
       return;
     }
     if (!window.PrototypeNotesModel) {
-      console.error('[prototype-notes] 缺少 PrototypeNotesModel，请先加载 client/notes/model.js。');
+      console.error('[prototype-notes] missing PrototypeNotesModel; load client/notes/model.js first.');
       return;
     }
     var data = window.__PROTOTYPE_NOTES__;
     if (!data || !Array.isArray(data.cards)) {
-      console.error('[prototype-notes] 缺少有效的 window.__PROTOTYPE_NOTES__ 数据。');
+      console.error('[prototype-notes] missing valid window.__PROTOTYPE_NOTES__ data.');
       return;
     }
     state.data = data;

--- a/tests/runtime/client/notes/viewer.test.mjs
+++ b/tests/runtime/client/notes/viewer.test.mjs
@@ -13,8 +13,8 @@ test('Notes Viewer 只保留 DOM/连线职责，状态与 when 逻辑由依赖�
   assert.doesNotMatch(source, /function matchesWhen/);
   assert.doesNotMatch(source, /function equalStateValue/);
   assert.match(source, /PrototypeNotesModel\.visibleCards/);
-  assert.match(source, /缺少 PrototypeViewers 状态内核/);
-  assert.match(source, /缺少 PrototypeNotesModel/);
+  assert.match(source, /missing PrototypeViewers state core/);
+  assert.match(source, /missing PrototypeNotesModel/);
 });
 
 test('Viewer 深链恢复只读取 scene', async () => {


### PR DESCRIPTION
## Summary

Localizes the minimal example, Notes Viewer, and Author Tools (Direct Edit + Mark) UI copy to English.

## Changes

- Example (examples/minimal-notes): lang="en", page title, menu, table, modals, toasts, and the notes snapshot/annotations copy.
- Viewer (skills/html-prototype-build/runtime/client/notes/viewer.js): scenario switch, hide/show notes, aria labels, and error messages.
- Author Tools (runtime/author/shell, direct-edit, mark): panel title, dirty bar, empty states, field labels, toasts.
- Docs: root README demo-language note removed (copy is now English); v0.3.1 CHANGELOG section added.
- Tests: synced the Viewer contract test with the localized error strings.

## Validation

npm test - 102/102 passing.
