### PR TITLE
fix(ui-pack-maintain): correct validate-pack false positives

### DIFF
--- a/skills/ui-pack-maintain/scripts/validate-pack.mjs
+++ b/skills/ui-pack-maintain/scripts/validate-pack.mjs
@@ -22,6 +22,22 @@ const referencedFiles = new Set(['PACK.md', 'manifest.json', 'design-system.md']
 const slash = (value) => value.split(path.sep).join('/');
 const isObject = (value) => value && typeof value === 'object' && !Array.isArray(value);
 const list = (value) => Array.isArray(value) ? value : [];
+const CSS_CUSTOM_PROPERTY_DECLARATION = /(--[a-zA-Z0-9_-]+)\s*:(?=\s|;|$)/g;
+const STATE_CLASS_PATTERN = /^is-[a-z0-9-]+$/;
+
+/** Strip block and line comments before static adapter checks. */
+function stripJsComments(source) {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:\\])\/\/.*$/gm, '$1');
+}
+
+/** Pack classes use manifest.classPrefix; local state hooks may use is-* modifiers. */
+function isAllowedClassName(className, classPrefix) {
+  if (!className) return true;
+  if (className.startsWith(classPrefix)) return true;
+  return STATE_CLASS_PATTERN.test(className);
+}
 
 async function fileExists(relativePath, rootDirectory = packDirectory) {
   try {
@@ -220,7 +236,10 @@ for (const [id, entry] of Object.entries(registries)) {
       [/\b(?:location|URLSearchParams)\b/, 'parses location or URLs'],
       [/(?:window|document)(?:\.|\[['"])(?:addEventListener|on[a-z]+)\b/, 'registers a global event handler']
     ];
-    for (const [pattern, reason] of forbidden) if (pattern.test(adapter)) errors.push(`${id} adapter ${reason}: ${entry.adapter}`);
+    const adapterBody = stripJsComments(adapter);
+    for (const [pattern, reason] of forbidden) {
+      if (pattern.test(adapterBody)) errors.push(`${id} adapter ${reason}: ${entry.adapter}`);
+    }
   }
   for (const dependency of [...list(entry.requires), ...list(entry.optional), ...list(entry.uses)]) {
     if (!registries[dependency]) errors.push(`${id} references unknown dependency: ${dependency}`);
@@ -275,7 +294,7 @@ if (strict) {
   for (const file of textFiles) {
     const source = await readText(file);
     if (/https?:\/\//i.test(source)) errors.push(`Pack implementation must not reference external URLs: ${file}`);
-    for (const match of source.matchAll(/(--[a-zA-Z0-9_-]+)\s*:/g)) {
+    for (const match of source.matchAll(CSS_CUSTOM_PROPERTY_DECLARATION)) {
       customProperties.add(match[1]);
       if (!match[1].startsWith(`--${manifest.tokenPrefix}`)) errors.push(`Token declaration does not use manifest.tokenPrefix in ${file}: ${match[1]}`);
     }
@@ -283,7 +302,9 @@ if (strict) {
     if (/\.(?:html?|js)$/.test(file)) {
       for (const match of source.matchAll(/\bclass\s*=\s*["']([^"']+)["']/gi)) {
         for (const className of match[1].trim().split(/\s+/)) {
-          if (className && !className.startsWith(manifest.classPrefix)) errors.push(`Class does not use manifest.classPrefix in ${file}: ${className}`);
+          if (className && !isAllowedClassName(className, manifest.classPrefix)) {
+            errors.push(`Class does not use manifest.classPrefix in ${file}: ${className}`);
+          }
         }
       }
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes three false positives in `ui-pack-maintain/scripts/validate-pack.mjs` that blocked `--strict` validation of the existing `admin-desktop` pack.

## Changes

1. **Adapter forbidden-API scan** — Strip block and line comments before checking adapters, so documentation such as "does not read PrototypeViewers" no longer fails validation.
2. **Token declaration regex** — Match CSS custom properties only when the colon starts a value (`: ` / `;` / end), avoiding BEM modifiers like `.ui-button--primary:hover`.
3. **Class prefix check** — Allow `is-*` state modifier classes (e.g. `is-active`, `is-open`) alongside `manifest.classPrefix` in HTML `class` attributes.

## Verification

- `node skills/ui-pack-maintain/scripts/validate-pack.mjs --pack=skills/html-prototype-build/ui/packs/admin-desktop --strict` passes
- Real `PrototypeViewers` usage in adapter code still fails validation
- `npm test` passes (102 tests)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1c2befd7-0d30-4907-9557-2c560e40ad64?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1c2befd7-0d30-4907-9557-2c560e40ad64&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

